### PR TITLE
feat(ui): aggiungere NumberStepper per contatori in CreateLeague

### DIFF
--- a/src/components/ui/NumberStepper.tsx
+++ b/src/components/ui/NumberStepper.tsx
@@ -1,0 +1,126 @@
+import { cn } from '../../lib/utils'
+
+interface NumberStepperProps {
+  value: number
+  onChange: (value: number) => void
+  min?: number
+  max?: number
+  step?: number
+  label?: string
+  error?: string
+  className?: string
+  size?: 'sm' | 'md' | 'lg'
+  showValue?: boolean
+}
+
+export function NumberStepper({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  label,
+  error,
+  className,
+  size = 'md',
+  showValue = true,
+}: NumberStepperProps) {
+  const handleDecrement = () => {
+    const newValue = value - step
+    if (newValue >= min) {
+      onChange(newValue)
+    }
+  }
+
+  const handleIncrement = () => {
+    const newValue = value + step
+    if (newValue <= max) {
+      onChange(newValue)
+    }
+  }
+
+  const isMinDisabled = value <= min
+  const isMaxDisabled = value >= max
+
+  const sizeClasses = {
+    sm: {
+      button: 'w-8 h-8 text-lg',
+      value: 'text-lg min-w-[3rem]',
+      container: 'gap-2',
+    },
+    md: {
+      button: 'w-10 h-10 text-xl',
+      value: 'text-xl min-w-[4rem]',
+      container: 'gap-3',
+    },
+    lg: {
+      button: 'w-12 h-12 text-2xl',
+      value: 'text-2xl min-w-[5rem]',
+      container: 'gap-4',
+    },
+  }
+
+  return (
+    <div className={cn('', className)}>
+      {label && (
+        <label className="block text-sm font-semibold text-gray-300 mb-2 uppercase tracking-wide">
+          {label}
+        </label>
+      )}
+
+      <div className={cn('flex items-center justify-center', sizeClasses[size].container)}>
+        {/* Decrement Button */}
+        <button
+          type="button"
+          onClick={handleDecrement}
+          disabled={isMinDisabled}
+          className={cn(
+            'flex items-center justify-center rounded-lg font-bold transition-all duration-200',
+            'bg-surface-300 border-2 border-surface-50/30 text-gray-300',
+            'hover:bg-primary-600 hover:border-primary-500 hover:text-white',
+            'active:scale-95',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-surface-300 disabled:hover:border-surface-50/30 disabled:hover:text-gray-300',
+            sizeClasses[size].button
+          )}
+          aria-label="Diminuisci"
+        >
+          −
+        </button>
+
+        {/* Value Display */}
+        {showValue && (
+          <span
+            className={cn(
+              'font-bold text-white text-center tabular-nums',
+              sizeClasses[size].value
+            )}
+          >
+            {value}
+          </span>
+        )}
+
+        {/* Increment Button */}
+        <button
+          type="button"
+          onClick={handleIncrement}
+          disabled={isMaxDisabled}
+          className={cn(
+            'flex items-center justify-center rounded-lg font-bold transition-all duration-200',
+            'bg-surface-300 border-2 border-surface-50/30 text-gray-300',
+            'hover:bg-primary-600 hover:border-primary-500 hover:text-white',
+            'active:scale-95',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-surface-300 disabled:hover:border-surface-50/30 disabled:hover:text-gray-300',
+            sizeClasses[size].button
+          )}
+          aria-label="Aumenta"
+        >
+          +
+        </button>
+      </div>
+
+      {error && (
+        <p className="mt-2 text-sm text-danger-400 text-center">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/src/pages/CreateLeague.tsx
+++ b/src/pages/CreateLeague.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type FormEvent } from 'react'
 import { leagueApi, superadminApi } from '../services/api'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
+import { NumberStepper } from '../components/ui/NumberStepper'
 import { Navigation } from '../components/Navigation'
 
 interface CreateLeagueProps {
@@ -215,11 +216,10 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
 
                   <div className="grid grid-cols-2 gap-6">
                     <div className="bg-surface-300 rounded-xl p-5 border border-surface-50/20">
-                      <Input
+                      <NumberStepper
                         label="Max Partecipanti"
-                        type="number"
                         value={maxParticipants}
-                        onChange={e => setMaxParticipants(Number(e.target.value))}
+                        onChange={setMaxParticipants}
                         min={2}
                         max={20}
                         error={fieldErrors.maxParticipants}
@@ -227,13 +227,13 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
                     </div>
 
                     <div className="bg-surface-300 rounded-xl p-5 border border-surface-50/20">
-                      <Input
+                      <NumberStepper
                         label="Budget Iniziale"
-                        type="number"
                         value={initialBudget}
-                        onChange={e => setInitialBudget(Number(e.target.value))}
+                        onChange={setInitialBudget}
                         min={100}
                         max={10000}
+                        step={50}
                         error={fieldErrors.initialBudget}
                       />
                     </div>
@@ -252,13 +252,12 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
                       <div className="w-12 h-12 rounded-full bg-gradient-to-br from-amber-500 to-amber-600 flex items-center justify-center mx-auto mb-3 text-white font-bold text-lg">
                         P
                       </div>
-                      <Input
-                        type="number"
+                      <NumberStepper
                         value={goalkeeperSlots}
-                        onChange={e => setGoalkeeperSlots(Number(e.target.value))}
+                        onChange={setGoalkeeperSlots}
                         min={1}
                         max={5}
-                        className="text-center"
+                        size="sm"
                       />
                       <p className="text-xs text-amber-400 mt-2">Portieri</p>
                     </div>
@@ -267,13 +266,12 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
                       <div className="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center mx-auto mb-3 text-white font-bold text-lg">
                         D
                       </div>
-                      <Input
-                        type="number"
+                      <NumberStepper
                         value={defenderSlots}
-                        onChange={e => setDefenderSlots(Number(e.target.value))}
+                        onChange={setDefenderSlots}
                         min={3}
                         max={12}
-                        className="text-center"
+                        size="sm"
                       />
                       <p className="text-xs text-blue-400 mt-2">Difensori</p>
                     </div>
@@ -282,13 +280,12 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
                       <div className="w-12 h-12 rounded-full bg-gradient-to-br from-emerald-500 to-emerald-600 flex items-center justify-center mx-auto mb-3 text-white font-bold text-lg">
                         C
                       </div>
-                      <Input
-                        type="number"
+                      <NumberStepper
                         value={midfielderSlots}
-                        onChange={e => setMidfielderSlots(Number(e.target.value))}
+                        onChange={setMidfielderSlots}
                         min={3}
                         max={12}
-                        className="text-center"
+                        size="sm"
                       />
                       <p className="text-xs text-emerald-400 mt-2">Centrocampisti</p>
                     </div>
@@ -297,13 +294,12 @@ export function CreateLeague({ onNavigate }: CreateLeagueProps) {
                       <div className="w-12 h-12 rounded-full bg-gradient-to-br from-red-500 to-red-600 flex items-center justify-center mx-auto mb-3 text-white font-bold text-lg">
                         A
                       </div>
-                      <Input
-                        type="number"
+                      <NumberStepper
                         value={forwardSlots}
-                        onChange={e => setForwardSlots(Number(e.target.value))}
+                        onChange={setForwardSlots}
                         min={2}
                         max={8}
-                        className="text-center"
+                        size="sm"
                       />
                       <p className="text-xs text-red-400 mt-2">Attaccanti</p>
                     </div>


### PR DESCRIPTION
## Summary
- Creato nuovo componente `NumberStepper` con pulsanti +/- 
- Sostituiti input numerici in CreateLeague per: Max Partecipanti, Budget Iniziale, Slot ruoli
- UX migliorata con controlli più intuitivi

## Test plan
- [ ] Verificare incremento/decremento con pulsanti +/-
- [ ] Verificare limiti min/max rispettati
- [ ] Verificare step di 50 per Budget Iniziale
- [ ] Testare su mobile

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)