### PR TITLE
feat: add interactive CALCOLO_INDENNIZZI phase to Mercato Ricorrente

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,6 +180,7 @@ function createLeagueNavigator(navigate: ReturnType<typeof useNavigate>, leagueI
       case 'rubata': navigate(`/leagues/${lid}/rubata`); break
       case 'strategie-rubata': navigate(`/leagues/${lid}/strategie-rubata`); break
       case 'svincolati': navigate(`/leagues/${lid}/svincolati`); break
+      case 'indemnity': navigate(`/leagues/${lid}/indemnity`); break
       case 'prizes': navigate(`/leagues/${lid}/prizes`); break
       case 'allPlayers': navigate(`/leagues/${lid}/players`); break
       case 'manager-dashboard': navigate(`/leagues/${lid}/manager`); break

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -135,6 +135,7 @@ function getPageDisplayName(page: string): string {
     trades: 'Scambi',
     rubata: 'Rubata',
     'strategie-rubata': 'Strategie Rubata',
+    indemnity: 'Indennizzi',
   }
   return pageNames[page] || page
 }

--- a/src/pages/LeagueDetail.tsx
+++ b/src/pages/LeagueDetail.tsx
@@ -42,6 +42,7 @@ interface Session {
 
 // Mapping fasi a nomi user-friendly
 const PHASE_LABELS: Record<string, string> = {
+  CALCOLO_INDENNIZZI: 'Calcolo Indennizzi',
   ASTA_LIBERA: 'Asta Primo Mercato',
   PREMI: 'Assegnazione Premi Budget',
   OFFERTE_PRE_RINNOVO: 'Scambi e Offerte',
@@ -257,6 +258,13 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
         {activeSession && (() => {
           const isFirstMarket = activeSession.type === 'PRIMO_MERCATO'
           const phaseConfig: Record<string, { icon: string; title: string; description: string; buttonText: string; color: string; adminOnly?: boolean }> = {
+            CALCOLO_INDENNIZZI: {
+              icon: '⚖️',
+              title: 'Calcolo Indennizzi',
+              description: 'Gestisci i giocatori usciti dalla Serie A: ritirati, retrocessi o trasferiti all\'estero.',
+              buttonText: 'Gestisci Indennizzi',
+              color: 'warning'
+            },
             ASTA_LIBERA: {
               icon: '🔨',
               title: isFirstMarket ? 'Asta Primo Mercato' : 'Asta Libera',
@@ -294,6 +302,7 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
           // Determine navigation target based on phase
           const getNavTarget = () => {
             switch (phase) {
+              case 'CALCOLO_INDENNIZZI': return () => onNavigate('indemnity', { leagueId })
               case 'ASTA_LIBERA': return () => onNavigate('auction', { sessionId: activeSession.id, leagueId })
               case 'PREMI': return () => onNavigate('prizes', { leagueId })
               case 'OFFERTE_PRE_RINNOVO':
@@ -513,6 +522,7 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
                     onClick={() => {
                       const phase = activeSession.currentPhase
                       switch (phase) {
+                        case 'CALCOLO_INDENNIZZI': onNavigate('indemnity', { leagueId }); break
                         case 'ASTA_LIBERA': onNavigate('auction', { sessionId: activeSession.id, leagueId }); break
                         case 'PREMI': onNavigate('prizes', { leagueId }); break
                         case 'OFFERTE_PRE_RINNOVO':


### PR DESCRIPTION
## Summary
- CALCOLO_INDENNIZZI is now the **first phase** of MERCATO_RICORRENTE, where managers must decide on players who left Serie A (RITIRATO/RETROCESSO/ESTERO)
- Replaced automatic processing with **interactive decision-making**: managers choose KEEP or RELEASE for affected players
- Phase advancement is gated until all managers with affected players have submitted decisions
- Full navigation wiring: Dashboard banner, breadcrumbs, phase click, admin panel with per-manager decision status

## Changes
- auction.service.ts: Set CALCOLO_INDENNIZZI as initial phase, reordered phase list, removed auto-processing call
- MarketPhaseManager.tsx: Added CALCOLO_INDENNIZZI phase config with indemnity status display
- AdminPanel.tsx: Fetches indemnity status from API and passes to MarketPhaseManager
- LeagueDetail.tsx: Added phase label, banner config, and navigation for CALCOLO_INDENNIZZI
- App.tsx: Added indemnity case to createLeagueNavigator()
- Navigation.tsx: Added breadcrumb display name for indemnity page

## Test plan
- [ ] Create a MERCATO_RICORRENTE session and verify it starts in CALCOLO_INDENNIZZI phase
- [ ] Verify Dashboard shows Calcolo Indennizzi banner with Gestisci Indennizzi button
- [ ] Click the banner button and verify navigation to Indemnity page
- [ ] Verify admin panel shows per-manager decision status
- [ ] If no affected players exist, verify phase can be advanced immediately
- [ ] Submit KEEP/RELEASE decisions as manager and verify status updates

Closes #154