### PR TITLE
feat: Indennizzi - calcolo automatico in PREMI e decisione in CONTRATTI

### DIFF
--- a/src/components/PrizePhaseManager.tsx
+++ b/src/components/PrizePhaseManager.tsx
@@ -516,6 +516,9 @@ export function PrizePhaseManager({ sessionId, isAdmin, onUpdate }: PrizePhaseMa
                   <p className="text-sm text-gray-400">
                     {data.indemnityStats.totalPlayers} giocatori con contratti attivi
                   </p>
+                  <p className="text-xs text-cyan-400 mt-0.5">
+                    Importi potenziali — pagati al consolidamento contratti se il manager rilascia il giocatore
+                  </p>
                 </div>
               </div>
               {/* Stats badges */}


### PR DESCRIPTION
## Summary

Closes #156

- **Elimina la fase CALCOLO_INDENNIZZI**: il mercato ricorrente parte direttamente da OFFERTE_PRE_RINNOVO
- **RITIRATO**: giocatori ritirati auto-rilasciati alla creazione sessione (movement RETIREMENT)
- **PREMI**: importi indennizzo visibili come "potenziali" ma NON aggiunti al budget alla finalizzazione (`isSystemPrize` esclusi)
- **CONTRATTI**: nuova sezione "Giocatori Usciti dalla Serie A" con toggle TIENI/RILASCIA
  - ESTERO + RILASCIA: nessun costo taglio, compenso = MIN(clausola_rescissione, indennizzoEstero)
  - RETROCESSO + RILASCIA: nessun costo taglio, nessun compenso
  - TIENI: contratto invariato, movement ABROAD_KEEP / RELEGATION_KEEP
- **Budget footer**: mostra voce Indennizzi quando applicabile

## Files changed
| File | Changes |
|------|---------|
| `auction.service.ts` | Fase iniziale OFFERTE_PRE_RINNOVO, auto-release RITIRATO, rimozione CALCOLO_INDENNIZZI |
| `contract.service.ts` | getContracts() flag usciti + compenso, consolidateContracts() logica differenziata |
| `prize-phase.service.ts` | finalizePrizePhase() esclude isSystemPrize dal budget |
| `indemnity-phase.service.ts` | Nuova autoReleaseRitiratiPlayers() |
| `Contracts.tsx` | Sezione giocatori usciti, toggle TIENI/RILASCIA, budget con indennizzi |
| `PrizePhaseManager.tsx` | Label "potenziale" su importi indennizzo |

## Test plan
- [ ] Creare MERCATO_RICORRENTE: parte da OFFERTE_PRE_RINNOVO
- [ ] Giocatori RITIRATO auto-rilasciati con movement RETIREMENT
- [ ] PREMI: importi indennizzo visibili ma NON aggiunti al budget
- [ ] CONTRATTI: giocatori RETROCESSO/ESTERO visibili con TIENI/RILASCIA
- [ ] RILASCIO ESTERO: budget += compenso, nessun costo taglio
- [ ] RILASCIO RETROCESSO: nessun costo, movement RELEGATION_RELEASE
- [ ] TIENI: movement corretto, contratto invariato
- [ ] Budget footer: mostra indennizzi quando presenti

🤖 Generated with [Claude Code](https://claude.com/claude-code)