### PR TITLE
fix: PlayerStatsModal crash when rating is string (#163)

### DIFF
--- a/src/components/PlayerStatsModal.tsx
+++ b/src/components/PlayerStatsModal.tsx
@@ -179,7 +179,7 @@ export function PlayerStatsModal({ isOpen, onClose, player }: PlayerStatsModalPr
             <StatSection title="Generali">
               <StatRow label="Presenze" value={stats.games.appearences} />
               <StatRow label="Minuti" value={stats.games.minutes} />
-              <StatRow label="Rating Medio" value={stats.games.rating ? Number(stats.games.rating.toFixed(2)) : null} />
+              <StatRow label="Rating Medio" value={stats.games.rating != null ? Number(Number(stats.games.rating).toFixed(2)) : null} />
             </StatSection>
 
             {/* Attacco */}


### PR DESCRIPTION
## Summary
- Fix crash when clicking player name in roster to view statistics
- `stats.games.rating` from API-Football JSON may be stored as string
- Convert to Number before calling `.toFixed()` to prevent TypeError

## Test plan
- [ ] Click on a player in roster view
- [ ] Verify stats modal opens without crash
- [ ] Verify rating displays correctly (e.g., 7.25)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)