### PR TITLE
fix: exclude RELEASED players from roster view (#165)

### DIFF
--- a/src/services/league.service.ts
+++ b/src/services/league.service.ts
@@ -775,6 +775,7 @@ export async function getAllRosters(leagueId: string, userId: string): Promise<S
             },
           },
           roster: {
+            where: { status: 'ACTIVE' },
             select: {
               id: true,
               playerId: true,


### PR DESCRIPTION
## Summary
- Add `where: { status: 'ACTIVE' }` filter to roster query in `getAllRosters`
- Players with RELEASED status will no longer appear in Rose page

## Test plan
- [ ] Verify released players (like Lazzari) don't appear in roster view
- [ ] Verify active players still appear correctly

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)