### PR TITLE
feat: unify Rose, Svincolati, and Strategie into single page

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -115,12 +115,11 @@ const MenuIcons = {
 
 // League menu items configuration
 // Note: Contratti, Scambi, Rubata are phase-specific and accessible from Rose or Dashboard when active
+// Note: Rose e Svincolati sono ora integrati nella pagina Strategie (renamed to Giocatori)
 const LEAGUE_MENU_ITEMS = [
   { key: 'leagueDetail', label: 'Dashboard', adminOnly: false, icon: 'dashboard' },
   { key: 'adminPanel', label: 'Admin', adminOnly: true, icon: 'admin' },
-  { key: 'rose', label: 'Rose', adminOnly: false, icon: 'roster' },
-  { key: 'strategie-rubata', label: 'Strategie', adminOnly: false, icon: 'strategy' },
-  { key: 'svincolati', label: 'Svincolati', adminOnly: false, icon: 'svincolati' },
+  { key: 'strategie-rubata', label: 'Giocatori', adminOnly: false, icon: 'allRosters' },
   { key: 'playerStats', label: 'Statistiche', adminOnly: false, icon: 'stats' },
   { key: 'history', label: 'Storico', adminOnly: false, icon: 'history' },
   { key: 'prophecies', label: 'Profezie', adminOnly: false, icon: 'prophecy' },


### PR DESCRIPTION
## Summary
- Remove Rose and Svincolati from navigation menu (code preserved for direct access)
- Rename menu item from Strategie to Giocatori with allRosters icon
- Add La Mia Rosa view mode to see own roster with contract details
- Keep existing views: Altre Rose (other managers), Svincolati (free agents), Tutti (all)
- Hide strategy columns (Max Bid, Priority, Notes) when viewing own roster
- Dynamic page description based on view mode
- Update footer stats for each view mode

## Test plan
- [ ] Navigate to Giocatori page from menu
- [ ] Verify 4 tabs work: La Mia Rosa, Altre Rose, Svincolati, Tutti
- [ ] La Mia Rosa shows own players without strategy fields
- [ ] Altre Rose shows strategy fields for other managers' players
- [ ] Mobile view works correctly for all modes

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)