### PR TITLE
feat: add goalkeeper stats (#189) and financial dashboard (#190)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ const Movements = lazy(() => import('./pages/Movements').then(m => ({ default: m
 const History = lazy(() => import('./pages/History').then(m => ({ default: m.History })))
 const Prophecies = lazy(() => import('./pages/Prophecies').then(m => ({ default: m.Prophecies })))
 const PlayerStats = lazy(() => import('./pages/PlayerStats'))
+const LeagueFinancials = lazy(() => import('./pages/LeagueFinancials'))
 const SuperAdmin = lazy(() => import('./pages/SuperAdmin').then(m => ({ default: m.SuperAdmin })))
 const PrizePhasePage = lazy(() => import('./pages/PrizePhasePage').then(m => ({ default: m.PrizePhasePage })))
 const LatencyTest = lazy(() => import('./pages/LatencyTest'))
@@ -561,6 +562,13 @@ function AppRoutes() {
         <ProtectedRoute>
           <Suspense fallback={<PageLoader />}>
             <PlayerStatsWrapper />
+          </Suspense>
+        </ProtectedRoute>
+      } />
+      <Route path="/leagues/:leagueId/financials" element={
+        <ProtectedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <LeagueFinancials />
           </Suspense>
         </ProtectedRoute>
       } />

--- a/src/api/routes/leagues.ts
+++ b/src/api/routes/leagues.ts
@@ -16,6 +16,7 @@ import {
   cancelJoinRequest,
   getAllRosters,
   searchLeagues,
+  getLeagueFinancials,
 } from '../../services/league.service'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth'
 
@@ -297,6 +298,24 @@ router.post('/:id/cancel-request', authMiddleware, async (req: Request, res: Res
     res.json(result)
   } catch (error) {
     console.error('Cancel join request error:', error)
+    res.status(500).json({ success: false, message: 'Errore interno del server' })
+  }
+})
+
+// GET /api/leagues/:id/financials - Get financial dashboard data (#190)
+router.get('/:id/financials', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const id = req.params.id as string
+    const result = await getLeagueFinancials(id, req.user!.userId)
+
+    if (!result.success) {
+      res.status(result.message === 'Non sei membro di questa lega' ? 403 : 404).json(result)
+      return
+    }
+
+    res.json(result)
+  } catch (error) {
+    console.error('Get league financials error:', error)
     res.status(500).json({ success: false, message: 'Errore interno del server' })
   }
 })

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -96,6 +96,11 @@ const MenuIcons = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
     </svg>
   ),
+  financials: (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
   chevronRight: (
     <svg className="w-3 h-3 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -121,6 +126,7 @@ const LEAGUE_MENU_ITEMS = [
   { key: 'adminPanel', label: 'Admin', adminOnly: true, icon: 'admin' },
   { key: 'strategie-rubata', label: 'Giocatori', adminOnly: false, icon: 'allRosters' },
   { key: 'playerStats', label: 'Statistiche', adminOnly: false, icon: 'stats' },
+  { key: 'financials', label: 'Finanze', adminOnly: false, icon: 'financials' },
   { key: 'history', label: 'Storico', adminOnly: false, icon: 'history' },
   { key: 'prophecies', label: 'Profezie', adminOnly: false, icon: 'prophecy' },
 ]
@@ -142,6 +148,7 @@ function getPageDisplayName(page: string): string {
     rubata: 'Rubata',
     'strategie-rubata': 'Strategie Rubata',
     playerStats: 'Statistiche Serie A',
+    financials: 'Finanze Lega',
   }
   return pageNames[page] || page
 }

--- a/src/components/PlayerStatsModal.tsx
+++ b/src/components/PlayerStatsModal.tsx
@@ -19,6 +19,8 @@ export interface PlayerStats {
   goals: {
     total: number | null
     assists: number | null
+    conceded: number | null  // Goalkeeper: goals conceded
+    saves: number | null     // Goalkeeper: saves
   }
   shots: {
     total: number | null
@@ -44,6 +46,7 @@ export interface PlayerStats {
   penalty: {
     scored: number | null
     missed: number | null
+    saved: number | null     // Goalkeeper: penalties saved
   }
 }
 
@@ -173,7 +176,50 @@ export function PlayerStatsModal({ isOpen, onClose, player }: PlayerStatsModalPr
               )}
             </div>
           </div>
+        ) : player.position === 'P' ? (
+          /* ========== GOALKEEPER STATS ========== */
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Generali */}
+            <StatSection title="Generali">
+              <StatRow label="Presenze" value={stats.games.appearences} />
+              <StatRow label="Minuti" value={stats.games.minutes} />
+              <StatRow label="Rating Medio" value={stats.games.rating != null ? Number(Number(stats.games.rating).toFixed(2)) : null} />
+            </StatSection>
+
+            {/* Portiere - Stats Principali */}
+            <StatSection title="🧤 Portiere">
+              <StatRow label="Parate" value={stats.goals.saves} />
+              <StatRow label="Gol Subiti" value={stats.goals.conceded} />
+              {stats.games.appearences && stats.goals.conceded != null && (
+                <StatRow
+                  label="Media Gol Subiti"
+                  value={Number((stats.goals.conceded / stats.games.appearences).toFixed(2))}
+                />
+              )}
+              {stats.games.appearences && stats.goals.conceded != null && stats.goals.conceded === 0 && (
+                <StatRow label="Clean Sheet" value={stats.games.appearences} />
+              )}
+            </StatSection>
+
+            {/* Passaggi */}
+            <StatSection title="Passaggi">
+              <StatRow label="Totali" value={stats.passes.total} />
+              <StatRow label="Precisione" value={stats.passes.accuracy} suffix="%" />
+            </StatSection>
+
+            {/* Rigori */}
+            <StatSection title="Rigori">
+              <StatRow label="Parati" value={stats.penalty.saved} />
+            </StatSection>
+
+            {/* Disciplina */}
+            <StatSection title="Disciplina">
+              <StatRow label="Cartellini Gialli" value={stats.cards.yellow} />
+              <StatRow label="Cartellini Rossi" value={stats.cards.red} />
+            </StatSection>
+          </div>
         ) : (
+          /* ========== OUTFIELD PLAYER STATS ========== */
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Generali */}
             <StatSection title="Generali">

--- a/src/pages/LeagueFinancials.tsx
+++ b/src/pages/LeagueFinancials.tsx
@@ -1,0 +1,480 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { Navigation } from '../components/Navigation'
+import { leagueApi } from '../services/api'
+
+// Types
+interface PlayerData {
+  id: string
+  name: string
+  team: string
+  position: string
+  quotation: number
+  age: number | null
+  salary: number
+  duration: number
+  clause: number
+}
+
+interface TeamData {
+  memberId: string
+  teamName: string
+  username: string
+  budget: number
+  annualContractCost: number
+  totalContractCost: number
+  slotCount: number
+  slotsFree: number
+  maxSlots: number
+  ageDistribution: {
+    under20: number
+    under25: number
+    under30: number
+    over30: number
+    unknown: number
+  }
+  positionDistribution: {
+    P: number
+    D: number
+    C: number
+    A: number
+  }
+  players: PlayerData[]
+}
+
+interface FinancialsData {
+  leagueName: string
+  maxSlots: number
+  teams: TeamData[]
+}
+
+// Sort field type
+type SortField = 'teamName' | 'budget' | 'annualContractCost' | 'totalContractCost' | 'slotCount' | 'under20' | 'under25' | 'under30' | 'over30'
+
+// Position colors
+const POSITION_COLORS: Record<string, string> = {
+  P: 'bg-yellow-500/20 text-yellow-400',
+  D: 'bg-green-500/20 text-green-400',
+  C: 'bg-blue-500/20 text-blue-400',
+  A: 'bg-red-500/20 text-red-400',
+}
+
+export default function LeagueFinancials() {
+  const { leagueId } = useParams<{ leagueId: string }>()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<FinancialsData | null>(null)
+  const [expandedTeam, setExpandedTeam] = useState<string | null>(null)
+  const [sortField, setSortField] = useState<SortField>('teamName')
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
+
+  useEffect(() => {
+    loadFinancials()
+  }, [leagueId])
+
+  async function loadFinancials() {
+    if (!leagueId) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await leagueApi.getFinancials(leagueId)
+      if (result.success && result.data) {
+        setData(result.data)
+      } else {
+        setError(result.message || 'Errore nel caricamento dei dati finanziari')
+      }
+    } catch {
+      setError('Errore di connessione')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Handle sorting
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(field)
+      setSortDirection('asc')
+    }
+  }
+
+  // Sorted teams
+  const sortedTeams = useMemo(() => {
+    if (!data?.teams) return []
+
+    return [...data.teams].sort((a, b) => {
+      let valueA: number | string
+      let valueB: number | string
+
+      switch (sortField) {
+        case 'teamName':
+          valueA = a.teamName.toLowerCase()
+          valueB = b.teamName.toLowerCase()
+          break
+        case 'budget':
+          valueA = a.budget
+          valueB = b.budget
+          break
+        case 'annualContractCost':
+          valueA = a.annualContractCost
+          valueB = b.annualContractCost
+          break
+        case 'totalContractCost':
+          valueA = a.totalContractCost
+          valueB = b.totalContractCost
+          break
+        case 'slotCount':
+          valueA = a.slotCount
+          valueB = b.slotCount
+          break
+        case 'under20':
+          valueA = a.ageDistribution.under20
+          valueB = b.ageDistribution.under20
+          break
+        case 'under25':
+          valueA = a.ageDistribution.under25
+          valueB = b.ageDistribution.under25
+          break
+        case 'under30':
+          valueA = a.ageDistribution.under30
+          valueB = b.ageDistribution.under30
+          break
+        case 'over30':
+          valueA = a.ageDistribution.over30
+          valueB = b.ageDistribution.over30
+          break
+        default:
+          return 0
+      }
+
+      if (valueA < valueB) return sortDirection === 'asc' ? -1 : 1
+      if (valueA > valueB) return sortDirection === 'asc' ? 1 : -1
+      return 0
+    })
+  }, [data?.teams, sortField, sortDirection])
+
+  // Calculate league totals
+  const totals = useMemo(() => {
+    if (!data?.teams) return null
+
+    return {
+      totalBudget: data.teams.reduce((sum, t) => sum + t.budget, 0),
+      totalAnnualCost: data.teams.reduce((sum, t) => sum + t.annualContractCost, 0),
+      totalContractCost: data.teams.reduce((sum, t) => sum + t.totalContractCost, 0),
+      totalPlayers: data.teams.reduce((sum, t) => sum + t.slotCount, 0),
+      avgAge: (() => {
+        const allPlayers = data.teams.flatMap(t => t.players).filter(p => p.age != null)
+        if (allPlayers.length === 0) return 0
+        return allPlayers.reduce((sum, p) => sum + (p.age || 0), 0) / allPlayers.length
+      })(),
+    }
+  }, [data?.teams])
+
+  // Sortable header component
+  const SortableHeader = ({ field, label, className = '' }: { field: SortField; label: string; className?: string }) => (
+    <th
+      className={`px-3 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider cursor-pointer hover:text-white transition-colors ${className}`}
+      onClick={() => handleSort(field)}
+    >
+      <div className="flex items-center gap-1">
+        {label}
+        {sortField === field && (
+          <span className="text-primary-400">{sortDirection === 'asc' ? '↑' : '↓'}</span>
+        )}
+      </div>
+    </th>
+  )
+
+  function handleNavigate(page: string) {
+    if (page === 'leagues') {
+      window.location.href = '/leagues'
+    } else if (leagueId) {
+      window.location.href = `/leagues/${leagueId}/${page}`
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-surface-200">
+        <Navigation
+          currentPage="financials"
+          leagueId={leagueId}
+          leagueName={data?.leagueName}
+          onNavigate={handleNavigate}
+        />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-surface-300 rounded w-1/3"></div>
+            <div className="h-64 bg-surface-300 rounded"></div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-surface-200">
+        <Navigation
+          currentPage="financials"
+          leagueId={leagueId}
+          onNavigate={handleNavigate}
+        />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="bg-danger-500/10 border border-danger-500/30 rounded-lg p-6 text-center">
+            <p className="text-danger-400">{error}</p>
+            <button
+              onClick={loadFinancials}
+              className="mt-4 px-4 py-2 bg-primary-500 text-white rounded hover:bg-primary-600 transition-colors"
+            >
+              Riprova
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-200">
+      <Navigation
+        currentPage="financials"
+        leagueId={leagueId}
+        leagueName={data?.leagueName}
+        onNavigate={handleNavigate}
+      />
+
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-white">Finanze Lega</h1>
+          <p className="text-gray-400 mt-1">Panoramica finanziaria di tutte le squadre</p>
+        </div>
+
+        {/* League Totals */}
+        {totals && (
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+            <div className="bg-surface-300/50 rounded-lg p-4 border border-surface-50/10">
+              <div className="text-xs text-gray-500 uppercase tracking-wider">Budget Totale</div>
+              <div className="text-xl font-bold text-primary-400">{totals.totalBudget}M</div>
+            </div>
+            <div className="bg-surface-300/50 rounded-lg p-4 border border-surface-50/10">
+              <div className="text-xs text-gray-500 uppercase tracking-wider">Costo Annuale</div>
+              <div className="text-xl font-bold text-accent-400">{totals.totalAnnualCost}M</div>
+            </div>
+            <div className="bg-surface-300/50 rounded-lg p-4 border border-surface-50/10">
+              <div className="text-xs text-gray-500 uppercase tracking-wider">Costo Totale</div>
+              <div className="text-xl font-bold text-warning-400">{totals.totalContractCost}M</div>
+            </div>
+            <div className="bg-surface-300/50 rounded-lg p-4 border border-surface-50/10">
+              <div className="text-xs text-gray-500 uppercase tracking-wider">Giocatori</div>
+              <div className="text-xl font-bold text-white">{totals.totalPlayers}</div>
+            </div>
+            <div className="bg-surface-300/50 rounded-lg p-4 border border-surface-50/10">
+              <div className="text-xs text-gray-500 uppercase tracking-wider">Età Media</div>
+              <div className="text-xl font-bold text-secondary-400">{totals.avgAge.toFixed(1)} anni</div>
+            </div>
+          </div>
+        )}
+
+        {/* Teams Table */}
+        <div className="bg-surface-300/30 rounded-xl border border-surface-50/10 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-surface-300/50">
+                <tr>
+                  <SortableHeader field="teamName" label="Squadra" />
+                  <SortableHeader field="budget" label="Budget" className="text-right" />
+                  <SortableHeader field="annualContractCost" label="Costo Ann." className="text-right" />
+                  <SortableHeader field="totalContractCost" label="Costo Tot." className="text-right" />
+                  <SortableHeader field="slotCount" label="Slot" className="text-center" />
+                  <th className="px-3 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">Ruoli</th>
+                  <SortableHeader field="under20" label="<20" className="text-center" />
+                  <SortableHeader field="under25" label="20-24" className="text-center" />
+                  <SortableHeader field="under30" label="25-29" className="text-center" />
+                  <SortableHeader field="over30" label="30+" className="text-center" />
+                  <th className="px-3 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-surface-50/10">
+                {sortedTeams.map((team) => {
+                  const isExpanded = expandedTeam === team.memberId
+                  const budgetLow = team.budget < 20
+
+                  return (
+                    <>
+                      <tr
+                        key={team.memberId}
+                        className={`hover:bg-surface-300/30 transition-colors ${budgetLow ? 'bg-danger-500/5' : ''}`}
+                      >
+                        {/* Team name */}
+                        <td className="px-3 py-4">
+                          <div className="font-medium text-white">{team.teamName}</div>
+                          <div className="text-xs text-gray-500">@{team.username}</div>
+                        </td>
+
+                        {/* Budget */}
+                        <td className={`px-3 py-4 text-right font-medium ${budgetLow ? 'text-danger-400' : 'text-primary-400'}`}>
+                          {team.budget}M
+                        </td>
+
+                        {/* Annual cost */}
+                        <td className="px-3 py-4 text-right font-medium text-accent-400">
+                          {team.annualContractCost}M
+                        </td>
+
+                        {/* Total cost */}
+                        <td className="px-3 py-4 text-right font-medium text-warning-400">
+                          {team.totalContractCost}M
+                        </td>
+
+                        {/* Slots */}
+                        <td className="px-3 py-4 text-center">
+                          <span className={`font-medium ${team.slotsFree === 0 ? 'text-danger-400' : 'text-white'}`}>
+                            {team.slotCount}
+                          </span>
+                          <span className="text-gray-500">/{team.maxSlots}</span>
+                        </td>
+
+                        {/* Position distribution */}
+                        <td className="px-3 py-4">
+                          <div className="flex items-center justify-center gap-1">
+                            {(['P', 'D', 'C', 'A'] as const).map(pos => (
+                              <span
+                                key={pos}
+                                className={`px-1.5 py-0.5 rounded text-xs font-medium ${POSITION_COLORS[pos]}`}
+                              >
+                                {team.positionDistribution[pos]}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+
+                        {/* Age distribution */}
+                        <td className="px-3 py-4 text-center">
+                          <span className="px-2 py-1 rounded bg-secondary-500/20 text-secondary-400 text-xs font-medium">
+                            {team.ageDistribution.under20}
+                          </span>
+                        </td>
+                        <td className="px-3 py-4 text-center">
+                          <span className="px-2 py-1 rounded bg-primary-500/20 text-primary-400 text-xs font-medium">
+                            {team.ageDistribution.under25}
+                          </span>
+                        </td>
+                        <td className="px-3 py-4 text-center">
+                          <span className="px-2 py-1 rounded bg-accent-500/20 text-accent-400 text-xs font-medium">
+                            {team.ageDistribution.under30}
+                          </span>
+                        </td>
+                        <td className="px-3 py-4 text-center">
+                          <span className="px-2 py-1 rounded bg-warning-500/20 text-warning-400 text-xs font-medium">
+                            {team.ageDistribution.over30}
+                          </span>
+                        </td>
+
+                        {/* Expand button */}
+                        <td className="px-3 py-4 text-center">
+                          <button
+                            onClick={() => setExpandedTeam(isExpanded ? null : team.memberId)}
+                            className="w-8 h-8 rounded-lg bg-surface-300 hover:bg-surface-50/20 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+                          >
+                            {isExpanded ? '−' : '+'}
+                          </button>
+                        </td>
+                      </tr>
+
+                      {/* Expanded player list */}
+                      {isExpanded && (
+                        <tr key={`${team.memberId}-expanded`}>
+                          <td colSpan={11} className="px-4 py-4 bg-surface-100/30">
+                            <div className="text-sm font-medium text-gray-400 mb-3">Rosa di {team.teamName}</div>
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                              {team.players
+                                .sort((a, b) => {
+                                  const posOrder = { P: 0, D: 1, C: 2, A: 3 }
+                                  return (posOrder[a.position as keyof typeof posOrder] || 99) - (posOrder[b.position as keyof typeof posOrder] || 99)
+                                })
+                                .map(player => (
+                                  <div
+                                    key={player.id}
+                                    className="flex items-center justify-between bg-surface-300/50 rounded-lg px-3 py-2"
+                                  >
+                                    <div className="flex items-center gap-2">
+                                      <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${POSITION_COLORS[player.position]}`}>
+                                        {player.position}
+                                      </span>
+                                      <div>
+                                        <div className="text-sm font-medium text-white">{player.name}</div>
+                                        <div className="text-xs text-gray-500">
+                                          {player.team}
+                                          {player.age != null && (
+                                            <span className="ml-2 text-gray-400">• {player.age} anni</span>
+                                          )}
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div className="text-right">
+                                      <div className="text-sm font-medium text-accent-400">{player.salary}M</div>
+                                      <div className="text-xs text-gray-500">{player.duration} stag.</div>
+                                    </div>
+                                  </div>
+                                ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="mt-6 bg-surface-300/30 rounded-lg p-4 border border-surface-50/10">
+          <h3 className="text-sm font-medium text-gray-400 mb-3">Legenda</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs">
+            <div>
+              <span className="text-primary-400 font-medium">Budget</span>
+              <span className="text-gray-500 ml-2">Crediti disponibili</span>
+            </div>
+            <div>
+              <span className="text-accent-400 font-medium">Costo Ann.</span>
+              <span className="text-gray-500 ml-2">Somma ingaggi stagione</span>
+            </div>
+            <div>
+              <span className="text-warning-400 font-medium">Costo Tot.</span>
+              <span className="text-gray-500 ml-2">Ingaggio × durata residua</span>
+            </div>
+            <div>
+              <span className="text-white font-medium">Slot</span>
+              <span className="text-gray-500 ml-2">Giocatori in rosa / max</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs mt-3">
+            <div className="flex items-center gap-2">
+              <span className="px-2 py-0.5 rounded bg-secondary-500/20 text-secondary-400 text-xs font-medium">&lt;20</span>
+              <span className="text-gray-500">Under 20</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="px-2 py-0.5 rounded bg-primary-500/20 text-primary-400 text-xs font-medium">20-24</span>
+              <span className="text-gray-500">Under 25</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="px-2 py-0.5 rounded bg-accent-500/20 text-accent-400 text-xs font-medium">25-29</span>
+              <span className="text-gray-500">Under 30</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="px-2 py-0.5 rounded bg-warning-500/20 text-warning-400 text-xs font-medium">30+</span>
+              <span className="text-gray-500">Over 30</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/StrategieRubata.tsx
+++ b/src/pages/StrategieRubata.tsx
@@ -1475,48 +1475,106 @@ export function StrategieRubata({ onNavigate }: { onNavigate: (page: string) => 
                 })}
               </div>
 
-              {/* Radar Charts */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
-                {/* Offensive Stats Radar */}
-                <div className="bg-surface-300/50 rounded-xl p-4">
-                  <h3 className="text-center text-white font-semibold mb-4">Statistiche Offensive</h3>
-                  <RadarChart
-                    size={280}
-                    players={playersToCompare.map((p, i) => ({
-                      name: p.playerName,
-                      color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
-                    }))}
-                    data={[
-                      { label: 'Gol', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.total ?? 0) },
-                      { label: 'Assist', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.assists ?? 0) },
-                      { label: 'Tiri', values: playersToCompare.map(p => p.playerApiFootballStats?.shots?.total ?? 0) },
-                      { label: 'Tiri Porta', values: playersToCompare.map(p => p.playerApiFootballStats?.shots?.on ?? 0) },
-                      { label: 'Dribbling', values: playersToCompare.map(p => p.playerApiFootballStats?.dribbles?.success ?? 0) },
-                      { label: 'Pass Chiave', values: playersToCompare.map(p => p.playerApiFootballStats?.passes?.key ?? 0) },
-                    ]}
-                  />
-                </div>
+              {/* Radar Charts - different for goalkeepers vs outfield players */}
+              {(() => {
+                const allGoalkeepers = playersToCompare.every(p => p.playerPosition === 'P')
+                const hasGoalkeepers = playersToCompare.some(p => p.playerPosition === 'P')
 
-                {/* Defensive/General Stats Radar */}
-                <div className="bg-surface-300/50 rounded-xl p-4">
-                  <h3 className="text-center text-white font-semibold mb-4">Statistiche Difensive</h3>
-                  <RadarChart
-                    size={280}
-                    players={playersToCompare.map((p, i) => ({
-                      name: p.playerName,
-                      color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
-                    }))}
-                    data={[
-                      { label: 'Contrasti', values: playersToCompare.map(p => p.playerApiFootballStats?.tackles?.total ?? 0) },
-                      { label: 'Intercetti', values: playersToCompare.map(p => p.playerApiFootballStats?.tackles?.interceptions ?? 0) },
-                      { label: 'Passaggi', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.passes?.total ?? 0) / 10)) },
-                      { label: 'Presenze', values: playersToCompare.map(p => p.playerApiFootballStats?.games?.appearences ?? 0) },
-                      { label: 'Rating', values: playersToCompare.map(p => Math.round((Number(p.playerApiFootballStats?.games?.rating) || 0) * 10)) },
-                      { label: 'Minuti', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.games?.minutes ?? 0) / 100)) },
-                    ]}
-                  />
-                </div>
-              </div>
+                if (allGoalkeepers) {
+                  // All goalkeepers - show goalkeeper-specific radar charts
+                  return (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
+                      {/* Goalkeeper Performance Radar */}
+                      <div className="bg-yellow-500/10 rounded-xl p-4 border border-yellow-500/20">
+                        <h3 className="text-center text-yellow-400 font-semibold mb-4">🧤 Performance Portiere</h3>
+                        <RadarChart
+                          size={280}
+                          players={playersToCompare.map((p, i) => ({
+                            name: p.playerName,
+                            color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
+                          }))}
+                          data={[
+                            { label: 'Parate', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.saves ?? 0) },
+                            { label: 'Rig. Parati', values: playersToCompare.map(p => (p.playerApiFootballStats?.penalty?.saved ?? 0) * 10) },
+                            { label: 'Rating', values: playersToCompare.map(p => Math.round((Number(p.playerApiFootballStats?.games?.rating) || 0) * 10)) },
+                            { label: 'Presenze', values: playersToCompare.map(p => p.playerApiFootballStats?.games?.appearences ?? 0) },
+                            { label: 'Minuti', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.games?.minutes ?? 0) / 100)) },
+                            { label: 'Passaggi', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.passes?.total ?? 0) / 10)) },
+                          ]}
+                        />
+                      </div>
+
+                      {/* Goalkeeper Goals Conceded Radar */}
+                      <div className="bg-yellow-500/10 rounded-xl p-4 border border-yellow-500/20">
+                        <h3 className="text-center text-yellow-400 font-semibold mb-4">🧤 Gol Subiti (meno è meglio)</h3>
+                        <RadarChart
+                          size={280}
+                          players={playersToCompare.map((p, i) => ({
+                            name: p.playerName,
+                            color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
+                          }))}
+                          data={[
+                            { label: 'Gol Subiti', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.conceded ?? 0) },
+                            { label: 'Prec. Pass', values: playersToCompare.map(p => p.playerApiFootballStats?.passes?.accuracy ?? 0) },
+                            { label: 'Gialli', values: playersToCompare.map(p => (p.playerApiFootballStats?.cards?.yellow ?? 0) * 5) },
+                            { label: 'Rossi', values: playersToCompare.map(p => (p.playerApiFootballStats?.cards?.red ?? 0) * 20) },
+                          ]}
+                        />
+                      </div>
+                    </div>
+                  )
+                }
+
+                // Mixed or outfield players - show standard radar charts
+                return (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
+                    {hasGoalkeepers && (
+                      <div className="col-span-full text-center text-sm text-yellow-400 bg-yellow-500/10 rounded-lg p-2 mb-2">
+                        ⚠️ Confronto misto portieri/giocatori - alcune statistiche potrebbero non essere comparabili
+                      </div>
+                    )}
+                    {/* Offensive Stats Radar */}
+                    <div className="bg-surface-300/50 rounded-xl p-4">
+                      <h3 className="text-center text-white font-semibold mb-4">Statistiche Offensive</h3>
+                      <RadarChart
+                        size={280}
+                        players={playersToCompare.map((p, i) => ({
+                          name: p.playerName,
+                          color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
+                        }))}
+                        data={[
+                          { label: 'Gol', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.total ?? 0) },
+                          { label: 'Assist', values: playersToCompare.map(p => p.playerApiFootballStats?.goals?.assists ?? 0) },
+                          { label: 'Tiri', values: playersToCompare.map(p => p.playerApiFootballStats?.shots?.total ?? 0) },
+                          { label: 'Tiri Porta', values: playersToCompare.map(p => p.playerApiFootballStats?.shots?.on ?? 0) },
+                          { label: 'Dribbling', values: playersToCompare.map(p => p.playerApiFootballStats?.dribbles?.success ?? 0) },
+                          { label: 'Pass Chiave', values: playersToCompare.map(p => p.playerApiFootballStats?.passes?.key ?? 0) },
+                        ]}
+                      />
+                    </div>
+
+                    {/* Defensive/General Stats Radar */}
+                    <div className="bg-surface-300/50 rounded-xl p-4">
+                      <h3 className="text-center text-white font-semibold mb-4">Statistiche Difensive</h3>
+                      <RadarChart
+                        size={280}
+                        players={playersToCompare.map((p, i) => ({
+                          name: p.playerName,
+                          color: PLAYER_CHART_COLORS[i % PLAYER_CHART_COLORS.length]
+                        }))}
+                        data={[
+                          { label: 'Contrasti', values: playersToCompare.map(p => p.playerApiFootballStats?.tackles?.total ?? 0) },
+                          { label: 'Intercetti', values: playersToCompare.map(p => p.playerApiFootballStats?.tackles?.interceptions ?? 0) },
+                          { label: 'Passaggi', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.passes?.total ?? 0) / 10)) },
+                          { label: 'Presenze', values: playersToCompare.map(p => p.playerApiFootballStats?.games?.appearences ?? 0) },
+                          { label: 'Rating', values: playersToCompare.map(p => Math.round((Number(p.playerApiFootballStats?.games?.rating) || 0) * 10)) },
+                          { label: 'Minuti', values: playersToCompare.map(p => Math.round((p.playerApiFootballStats?.games?.minutes ?? 0) / 100)) },
+                        ]}
+                      />
+                    </div>
+                  </div>
+                )
+              })()}
 
               {/* Detailed Stats Table */}
               <div className="bg-surface-300/30 rounded-xl overflow-hidden">
@@ -1585,11 +1643,16 @@ export function StrategieRubata({ onNavigate }: { onNavigate: (page: string) => 
                           </tr>
                         </>
                       )}
-                      {/* Stats */}
+                      {/* Stats - includes goalkeeper-specific stats */}
                       {[
                         { label: 'Presenze', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.games?.appearences },
                         { label: 'Minuti', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.games?.minutes },
                         { label: 'Rating', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.games?.rating, format: (v: number | null) => v != null ? Number(v).toFixed(2) : '-' },
+                        // Goalkeeper-specific stats
+                        { label: '🧤 Parate', getValue: (p: DisplayPlayer) => p.playerPosition === 'P' ? p.playerApiFootballStats?.goals?.saves : null, colorClass: 'text-yellow-400', goalkeeperOnly: true },
+                        { label: '🧤 Gol Subiti', getValue: (p: DisplayPlayer) => p.playerPosition === 'P' ? p.playerApiFootballStats?.goals?.conceded : null, colorClass: 'text-yellow-400', goalkeeperOnly: true, lowerIsBetter: true },
+                        { label: '🧤 Rigori Parati', getValue: (p: DisplayPlayer) => p.playerPosition === 'P' ? p.playerApiFootballStats?.penalty?.saved : null, colorClass: 'text-yellow-400', goalkeeperOnly: true },
+                        // Outfield stats
                         { label: 'Gol', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.goals?.total, colorClass: 'text-secondary-400' },
                         { label: 'Assist', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.goals?.assists, colorClass: 'text-primary-400' },
                         { label: 'Tiri Totali', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.shots?.total },
@@ -1601,7 +1664,13 @@ export function StrategieRubata({ onNavigate }: { onNavigate: (page: string) => 
                         { label: 'Dribbling Riusciti', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.dribbles?.success },
                         { label: 'Ammonizioni', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.cards?.yellow, colorClass: 'text-warning-400' },
                         { label: 'Espulsioni', getValue: (p: DisplayPlayer) => p.playerApiFootballStats?.cards?.red, colorClass: 'text-danger-400' },
-                      ].map(row => {
+                      ].filter(row => {
+                        // Hide goalkeeper-only rows if no goalkeepers in comparison
+                        if ((row as { goalkeeperOnly?: boolean }).goalkeeperOnly) {
+                          return playersToCompare.some(p => p.playerPosition === 'P')
+                        }
+                        return true
+                      }).map(row => {
                         const values = playersToCompare.map(p => {
                           const val = row.getValue(p)
                           return val != null ? Number(val) : 0

--- a/src/services/api-football.service.ts
+++ b/src/services/api-football.service.ts
@@ -46,13 +46,13 @@ interface ApiPlayerStats {
     team: { id: number; name: string }
     league: { id: number; name: string; season: number }
     games: { appearences: number | null; minutes: number | null; rating: string | null }
-    goals: { total: number | null; assists: number | null }
+    goals: { total: number | null; assists: number | null; conceded: number | null; saves: number | null }
     shots: { total: number | null; on: number | null }
     passes: { total: number | null; key: number | null; accuracy: number | null }
     tackles: { total: number | null; interceptions: number | null }
     dribbles: { attempts: number | null; success: number | null }
     cards: { yellow: number | null; red: number | null }
-    penalty: { scored: number | null; missed: number | null }
+    penalty: { scored: number | null; missed: number | null; saved: number | null }
   }>
 }
 
@@ -526,6 +526,8 @@ export async function syncStats(userId: string): Promise<SyncResult> {
           goals: {
             total: serieAStats.goals.total,
             assists: serieAStats.goals.assists,
+            conceded: serieAStats.goals.conceded,  // Goalkeeper: goals conceded
+            saves: serieAStats.goals.saves,        // Goalkeeper: saves
           },
           shots: {
             total: serieAStats.shots.total,
@@ -551,6 +553,7 @@ export async function syncStats(userId: string): Promise<SyncResult> {
           penalty: {
             scored: serieAStats.penalty.scored,
             missed: serieAStats.penalty.missed,
+            saved: serieAStats.penalty.saved,      // Goalkeeper: penalties saved
           },
         }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -194,6 +194,48 @@ export const leagueApi = {
       adminUsername: string
       createdAt: string
     }>>(`/api/leagues/search?q=${encodeURIComponent(query)}`),
+
+  // Get financial dashboard data (#190)
+  getFinancials: (leagueId: string) =>
+    request<{
+      leagueName: string
+      maxSlots: number
+      teams: Array<{
+        memberId: string
+        teamName: string
+        username: string
+        budget: number
+        annualContractCost: number
+        totalContractCost: number
+        slotCount: number
+        slotsFree: number
+        maxSlots: number
+        ageDistribution: {
+          under20: number
+          under25: number
+          under30: number
+          over30: number
+          unknown: number
+        }
+        positionDistribution: {
+          P: number
+          D: number
+          C: number
+          A: number
+        }
+        players: Array<{
+          id: string
+          name: string
+          team: string
+          position: string
+          quotation: number
+          age: number | null
+          salary: number
+          duration: number
+          clause: number
+        }>
+      }>
+    }>(`/api/leagues/${leagueId}/financials`),
 }
 
 // Invite API

--- a/src/services/league.service.ts
+++ b/src/services/league.service.ts
@@ -930,3 +930,130 @@ export async function searchLeagues(
     data: filteredLeagues,
   }
 }
+
+/**
+ * Get financial dashboard data for all teams in a league (#190)
+ */
+export async function getLeagueFinancials(leagueId: string, userId: string): Promise<ServiceResult> {
+  // Verify user is a member of the league
+  const membership = await prisma.leagueMember.findFirst({
+    where: {
+      leagueId,
+      userId,
+      status: MemberStatus.ACTIVE,
+    },
+  })
+
+  if (!membership) {
+    return { success: false, message: 'Non sei membro di questa lega' }
+  }
+
+  // Get all active members with their rosters and contracts
+  const members = await prisma.leagueMember.findMany({
+    where: {
+      leagueId,
+      status: MemberStatus.ACTIVE,
+    },
+    include: {
+      user: {
+        select: { username: true },
+      },
+      roster: {
+        where: { status: 'ACTIVE' },
+        include: {
+          player: {
+            select: {
+              id: true,
+              name: true,
+              team: true,
+              position: true,
+              quotation: true,
+              age: true,
+            },
+          },
+          contract: {
+            select: {
+              salary: true,
+              duration: true,
+              rescissionClause: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: { teamName: 'asc' },
+  })
+
+  // Get league settings for slot limit
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: { maxRosterSize: true, name: true },
+  })
+
+  const maxSlots = league?.maxRosterSize || 25
+
+  // Calculate financial data for each team
+  const teamsData = members.map(member => {
+    const players = member.roster.map(r => ({
+      id: r.player.id,
+      name: r.player.name,
+      team: r.player.team,
+      position: r.player.position,
+      quotation: r.player.quotation,
+      age: r.player.age,
+      salary: r.contract?.salary || 0,
+      duration: r.contract?.duration || 0,
+      clause: r.contract?.rescissionClause || 0,
+    }))
+
+    // Calculate totals
+    const annualContractCost = players.reduce((sum, p) => sum + p.salary, 0)
+    const totalContractCost = players.reduce((sum, p) => sum + (p.salary * p.duration), 0)
+    const slotCount = players.length
+
+    // Age distribution
+    const under20 = players.filter(p => p.age != null && p.age < 20).length
+    const under25 = players.filter(p => p.age != null && p.age >= 20 && p.age < 25).length
+    const under30 = players.filter(p => p.age != null && p.age >= 25 && p.age < 30).length
+    const over30 = players.filter(p => p.age != null && p.age >= 30).length
+    const ageUnknown = players.filter(p => p.age == null).length
+
+    // Position distribution
+    const byPosition = {
+      P: players.filter(p => p.position === 'P').length,
+      D: players.filter(p => p.position === 'D').length,
+      C: players.filter(p => p.position === 'C').length,
+      A: players.filter(p => p.position === 'A').length,
+    }
+
+    return {
+      memberId: member.id,
+      teamName: member.teamName || member.user.username,
+      username: member.user.username,
+      budget: member.currentBudget,
+      annualContractCost,
+      totalContractCost,
+      slotCount,
+      slotsFree: maxSlots - slotCount,
+      maxSlots,
+      ageDistribution: {
+        under20,
+        under25,
+        under30,
+        over30,
+        unknown: ageUnknown,
+      },
+      positionDistribution: byPosition,
+      players, // Include player details for drill-down
+    }
+  })
+
+  return {
+    success: true,
+    data: {
+      leagueName: league?.name,
+      maxSlots,
+      teams: teamsData,
+    },
+  }
+}

--- a/src/services/rubata.service.ts
+++ b/src/services/rubata.service.ts
@@ -3775,6 +3775,7 @@ export async function getAllPlayersForStrategies(
               team: true,
               position: true,
               quotation: true,
+              age: true,  // #190: include age for financial dashboard
               apiFootballId: true,
               apiFootballStats: true,
             },
@@ -3801,6 +3802,7 @@ export async function getAllPlayersForStrategies(
     playerPosition: string
     playerTeam: string
     playerQuotation: number
+    playerAge: number | null  // #190: player age
     playerApiFootballId: number | null
     playerApiFootballStats: unknown
     ownerUsername: string
@@ -3828,6 +3830,7 @@ export async function getAllPlayersForStrategies(
         playerPosition: rosterEntry.player.position,
         playerTeam: rosterEntry.player.team,
         playerQuotation: rosterEntry.player.quotation,
+        playerAge: rosterEntry.player.age,  // #190: player age
         playerApiFootballId: rosterEntry.player.apiFootballId,
         playerApiFootballStats: rosterEntry.player.apiFootballStats,
         ownerUsername: memberData.user.username,
@@ -3957,6 +3960,7 @@ export async function getAllSvincolatiForStrategies(
       team: true,
       position: true,
       quotation: true,
+      age: true,  // #190: include age
       apiFootballId: true,
       apiFootballStats: true,
     },
@@ -3972,6 +3976,7 @@ export async function getAllSvincolatiForStrategies(
     playerName: player.name,
     playerPosition: player.position,
     playerTeam: player.team,
+    playerAge: player.age,  // #190: include age
     playerApiFootballId: player.apiFootballId,
     playerApiFootballStats: player.apiFootballStats,
     preference: preferencesMap.get(player.id) || null,


### PR DESCRIPTION
## Summary
- **#189**: Statistiche specifiche per i portieri (Parate, Gol Subiti, Rigori Parati)
- **#190**: Dashboard finanziaria con budget, costi contratti e composizione rose

## Modifiche

### #189 - Statistiche Portieri
- Backend: Aggiunto goals.conceded, goals.saves, penalty.saved a ApiPlayerStats
- PlayerStatsModal: Sezione dedicata per portieri con stats rilevanti
- Confronto: Radar chart specifici per portieri, warning per confronti misti

### #190 - Dashboard Finanziaria
- Nuovo endpoint API: GET /api/leagues/:id/financials
- Nuova pagina LeagueFinancials con:
  - Budget, costo contratti annuale/totale per squadra
  - Slot occupati/liberi
  - Distribuzione età: under20, under25, under30, over30
  - Distribuzione ruoli: P, D, C, A
  - Dettaglio giocatori espandibile
  - Totali lega
  - Colonne ordinabili
  - Legenda metriche
- Nuova voce menu Finanze con icona valuta
- Età giocatore inclusa in tutte le API (owned + svincolati)

## Test plan
- [ ] Verificare stats specifiche portieri nel modal
- [ ] Confrontare 2 portieri e verificare radar chart dedicato
- [ ] Confrontare portiere + giocatore e verificare warning
- [ ] Aprire pagina Finanze e verificare dati corretti
- [ ] Ordinare per ogni colonna
- [ ] Espandere dettaglio squadra

Closes #189, Closes #190