### PR TITLE
feat(#192): Finanze drill-down aggregato con grafici

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,7 +183,10 @@ function createLeagueNavigator(navigate: ReturnType<typeof useNavigate>, leagueI
       case 'strategie-rubata': navigate(`/leagues/${lid}/strategie-rubata`); break
       case 'svincolati': navigate(`/leagues/${lid}/svincolati`); break
       case 'prizes': navigate(`/leagues/${lid}/prizes`); break
-      case 'allPlayers': navigate(`/leagues/${lid}/players`); break
+      case 'allPlayers':
+        if (params?.team) navigate(`/leagues/${lid}/players?team=${encodeURIComponent(params.team)}`)
+        else navigate(`/leagues/${lid}/players`)
+        break
       case 'manager-dashboard': navigate(`/leagues/${lid}/manager`); break
       case 'admin':
       case 'adminPanel':
@@ -292,10 +295,12 @@ function SvincolatiWrapper() {
 function AllPlayersWrapper() {
   const navigate = useNavigate()
   const { leagueId } = useParams<{ leagueId: string }>()
+  const [searchParams] = useSearchParams()
+  const teamFilter = searchParams.get('team') || undefined
   const onNavigate = useCallback(createLeagueNavigator(navigate, leagueId), [navigate, leagueId])
 
   if (!leagueId) return <Navigate to="/dashboard" replace />
-  return <AllPlayers leagueId={leagueId} onNavigate={onNavigate} />
+  return <AllPlayers leagueId={leagueId} onNavigate={onNavigate} initialTeamFilter={teamFilter} />
 }
 
 function ManagerDashboardWrapper() {


### PR DESCRIPTION
## Summary
- Sostituita la tabella dei singoli giocatori nel drill-down con una **vista aggregata per ruolo** (P/D/C/A)
- Aggiunto **donut chart** per visualizzare la distribuzione dei costi per ruolo
- Aggiunto **bar chart** per confrontare budget disponibile vs costi contratti
- Aggiunto bottone **Vedi Giocatori** che naviga alla pagina AllPlayers con il filtro squadra pre-applicato

## Dettagli implementazione
- Grafici realizzati in **pure SVG** senza dipendenze esterne (niente recharts)
- AllPlayers ora supporta il parametro URL `?team=TEAM_NAME` per filtrare i giocatori di una squadra
- Aggiunto dropdown per filtrare per squadra nella pagina AllPlayers

## Test plan
- [ ] Aprire la pagina Finanze di una lega
- [ ] Cliccare su una squadra per espandere il drill-down
- [ ] Verificare che mostri la vista aggregata con conteggi e costi per ruolo
- [ ] Verificare che il donut chart mostri la distribuzione corretta
- [ ] Verificare che il bar chart mostri budget vs contratti
- [ ] Cliccare su Vedi Giocatori e verificare che navighi a AllPlayers con il filtro squadra applicato
- [ ] Verificare che il dropdown squadra funzioni correttamente in AllPlayers

Closes #192

---
Generated with [Claude Code](https://claude.ai/code)