### PR TITLE
feat(#201): default contract duration 3 in svincolati auction

### DIFF
--- a/src/components/ContractModifier.tsx
+++ b/src/components/ContractModifier.tsx
@@ -20,7 +20,8 @@ function isValidModification(
   currentDuration: number,
   newSalary: number,
   newDuration: number,
-  initialSalary: number
+  initialSalary: number,
+  isSvincolatiMode: boolean = false
 ): { valid: boolean; reason?: string } {
   // Max duration check
   if (newDuration > 4) {
@@ -31,6 +32,21 @@ function isValidModification(
   if (newSalary < 1) {
     return { valid: false, reason: 'Ingaggio minimo: 1' }
   }
+
+  // Svincolati mode: minimum duration is 3, salary can only increase
+  if (isSvincolatiMode) {
+    if (newDuration < 3) {
+      return { valid: false, reason: 'Durata minima per svincolati: 3 semestri' }
+    }
+    if (newSalary < currentSalary) {
+      return { valid: false, reason: `Ingaggio non può diminuire: ${newSalary} < ${currentSalary}` }
+    }
+    if (newDuration < currentDuration) {
+      return { valid: false, reason: `Durata non può diminuire: ${newDuration} < ${currentDuration}` }
+    }
+    return { valid: true }
+  }
+
   if (newDuration < 1) {
     return { valid: false, reason: 'Durata minima: 1 semestre' }
   }
@@ -86,6 +102,8 @@ interface ContractModifierProps {
   title?: string
   /** Description text */
   description?: string
+  /** Svincolati mode: minimum duration is 3, salary can only increase */
+  isSvincolatiMode?: boolean
 }
 
 export function ContractModifier({
@@ -96,11 +114,15 @@ export function ContractModifier({
   isLoading = false,
   title = 'Modifica Contratto',
   description = 'Puoi modificare il contratto del giocatore appena acquisito seguendo le regole del rinnovo.',
+  isSvincolatiMode = false,
 }: ContractModifierProps) {
   const [newSalary, setNewSalary] = useState(contract.salary.toString())
   const [newDuration, setNewDuration] = useState(contract.duration)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Calculate minimum duration based on mode
+  const minDuration = isSvincolatiMode ? 3 : 1
 
   // Reset when contract changes
   useEffect(() => {
@@ -119,7 +141,8 @@ export function ContractModifier({
       contract.duration,
       salary,
       duration,
-      contract.initialSalary
+      contract.initialSalary,
+      isSvincolatiMode
     )
 
     const newClause = calculateRescissionClause(salary, duration)
@@ -133,10 +156,10 @@ export function ContractModifier({
       validationError: validation.reason,
       hasChanges,
     }
-  }, [newSalary, newDuration, contract])
+  }, [newSalary, newDuration, contract, isSvincolatiMode])
 
-  // Check if spalma is available
-  const canSpalma = contract.duration === 1
+  // Check if spalma is available (not in svincolati mode)
+  const canSpalma = !isSvincolatiMode && contract.duration === 1
 
   async function handleConfirm() {
     if (!preview.isValid || !preview.hasChanges) return
@@ -219,9 +242,10 @@ export function ContractModifier({
                 type="button"
                 onClick={() => {
                   const current = parseInt(newSalary) || contract.salary
-                  setNewSalary(String(Math.max(1, current - 1)))
+                  const minSalary = isSvincolatiMode ? contract.salary : 1
+                  setNewSalary(String(Math.max(minSalary, current - 1)))
                 }}
-                disabled={isLoading || isSubmitting || (parseInt(newSalary) || contract.salary) <= 1}
+                disabled={isLoading || isSubmitting || (parseInt(newSalary) || contract.salary) <= (isSvincolatiMode ? contract.salary : 1)}
                 className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l-lg text-white font-bold disabled:opacity-30 hover:bg-surface-300/80 transition-colors"
               >−</button>
               <div className="flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">
@@ -245,8 +269,8 @@ export function ContractModifier({
             <div className="flex items-center">
               <button
                 type="button"
-                onClick={() => setNewDuration(Math.max(1, newDuration - 1))}
-                disabled={isLoading || isSubmitting || newDuration <= 1}
+                onClick={() => setNewDuration(Math.max(minDuration, newDuration - 1))}
+                disabled={isLoading || isSubmitting || newDuration <= minDuration}
                 className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l-lg text-white font-bold disabled:opacity-30 hover:bg-surface-300/80 transition-colors"
               >−</button>
               <div className="flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">

--- a/src/pages/Svincolati.tsx
+++ b/src/pages/Svincolati.tsx
@@ -2274,7 +2274,8 @@ export function Svincolati({ leagueId, onNavigate }: SvincolatiProps) {
           }}
           onConfirm={handleContractModification}
           title="Modifica Contratto"
-          description="Hai appena acquistato questo svincolato. Puoi modificare il suo contratto seguendo le regole del rinnovo."
+          description="Hai appena acquistato questo svincolato. Puoi solo aumentare ingaggio (minimo attuale) e durata (minimo 3, massimo 4 semestri)."
+          isSvincolatiMode={true}
         />
       )}
 

--- a/src/services/svincolati.service.ts
+++ b/src/services/svincolati.service.ts
@@ -491,10 +491,10 @@ export async function closeFreeAgentAuction(
       },
     })
 
-    // Create contract automatically: 10% salary, 2 semesters (same as first market)
+    // Create contract automatically: 10% salary, 3 semesters (svincolati default)
     const salary = Math.ceil(auction.currentPrice * 0.1)
-    const duration = 2
-    const rescissionClause = Math.round(salary * duration * 2)
+    const duration = 3
+    const rescissionClause = salary * 9 // multiplier for 3 semesters
 
     await tx.playerContract.create({
       data: {
@@ -521,8 +521,8 @@ export async function closeFreeAgentAuction(
 
   // Record movement with contract values
   const movementSalary = Math.ceil(auction.currentPrice * 0.1)
-  const movementDuration = 2
-  const movementClause = Math.round(movementSalary * movementDuration * 2)
+  const movementDuration = 3
+  const movementClause = movementSalary * 9 // multiplier for 3 semesters
 
   await recordMovement({
     leagueId: auction.leagueId,
@@ -1530,10 +1530,10 @@ export async function closeSvincolatiAuction(
       },
     })
 
-    // Create contract automatically: 10% salary, 2 semesters (same as first market)
+    // Create contract automatically: 10% salary, 3 semesters (svincolati default)
     const salary = Math.ceil(auction.currentPrice * 0.1)
-    const duration = 2
-    const rescissionClause = Math.round(salary * duration * 2)
+    const duration = 3
+    const rescissionClause = salary * 9 // multiplier for 3 semesters
 
     await tx.playerContract.create({
       data: {
@@ -1579,8 +1579,8 @@ export async function closeSvincolatiAuction(
 
   // Record movement with contract values
   const movementSalary2 = Math.ceil(auction.currentPrice * 0.1)
-  const movementDuration2 = 2
-  const movementClause2 = Math.round(movementSalary2 * movementDuration2 * 2)
+  const movementDuration2 = 3
+  const movementClause2 = movementSalary2 * 9 // multiplier for 3 semesters
 
   await recordMovement({
     leagueId: auction.leagueId,


### PR DESCRIPTION
## Summary
- Changed default contract duration from 2 to 3 semesters for svincolati acquisitions
- Added isSvincolatiMode prop to ContractModifier component for special handling
- In svincolati mode: minimum duration is 3 (can only increase to 4), salary can only increase (not decrease)
- Updated rescission clause calculation to use multiplier 9 for 3 semesters
- Disabled decrease buttons when at minimum values in svincolati mode

## Changes
- **src/services/svincolati.service.ts**: Updated both closeFreeAgentAuction and closeSvincolatiAuction functions to create contracts with duration 3 and appropriate rescission clause
- **src/components/ContractModifier.tsx**: Added isSvincolatiMode prop that:
  - Sets minimum duration to 3
  - Prevents salary decrease (salary can only increase)
  - Prevents duration decrease below 3
  - Disables spalma option
- **src/pages/Svincolati.tsx**: Added isSvincolatiMode=true to ContractModifierModal and updated description text

## Test plan
- [ ] Win a player in svincolati auction
- [ ] Verify contract is created with duration 3 and salary = ceil(price * 0.1)
- [ ] Open contract modification modal and verify:
  - [ ] Duration shows 3s, can increase to 4 but not decrease
  - [ ] Salary shows correct value, can increase but not decrease
  - [ ] Spalma option is not shown

Closes #201

Generated with [Claude Code](https://claude.com/claude-code)