### PR TITLE
feat(#207): require salary increase before allowing duration increase

### DIFF
--- a/src/pages/Contracts.tsx
+++ b/src/pages/Contracts.tsx
@@ -1282,6 +1282,11 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                 ? Math.ceil(contract.initialSalary / newDuration)
                 : contract.salary
 
+              // Issue #207: Cannot increase duration unless salary is also increased
+              // Exception: canSpalmare=true cases (spalma allows duration extension without salary increase)
+              const hasSalaryIncrease = newSalary > contract.salary
+              const canIncreaseDuration = contract.canSpalmare || hasSalaryIncrease
+
               return (
                 <div key={contract.id} className={`bg-surface-200 rounded-lg border p-3 ${
                   isMarkedForRelease ? 'border-danger-500/50 bg-danger-500/10' : 'border-surface-50/20'
@@ -1432,8 +1437,9 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                             </div>
                             <button
                               onClick={() => updateLocalEdit(contract.id, 'newDuration', String(newDuration + 1))}
-                              disabled={newDuration >= 4}
+                              disabled={newDuration >= 4 || !canIncreaseDuration}
                               className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
+                              title={!canIncreaseDuration ? 'Aumenta prima l\'ingaggio per estendere la durata' : undefined}
                             >+</button>
                           </div>
                         </div>
@@ -1531,6 +1537,11 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                     const minSalaryAllowed = contract.canSpalmare && newDuration > 1
                       ? Math.ceil(contract.initialSalary / newDuration)
                       : contract.salary
+
+                    // Issue #207: Cannot increase duration unless salary is also increased
+                    // Exception: canSpalmare=true cases (spalma allows duration extension without salary increase)
+                    const hasSalaryIncrease = newSalary > contract.salary
+                    const canIncreaseDuration = contract.canSpalmare || hasSalaryIncrease
 
                     return (
                       <tr key={contract.id} className={`border-t border-surface-50/10 hover:bg-surface-300/30 ${
@@ -1630,8 +1641,9 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                               <span className={`w-8 text-center font-medium ${getDurationColor(newDuration)}`}>{newDuration}s</span>
                               <button
                                 onClick={() => updateLocalEdit(contract.id, 'newDuration', String(newDuration + 1))}
-                                disabled={newDuration >= 4}
+                                disabled={newDuration >= 4 || !canIncreaseDuration}
                                 className="w-6 h-6 bg-surface-300 border border-primary-500/30 rounded text-white text-sm disabled:opacity-30"
+                                title={!canIncreaseDuration ? 'Aumenta prima l\'ingaggio per estendere la durata' : undefined}
                               >+</button>
                             </div>
                           ) : (


### PR DESCRIPTION
## Summary
- In the Contracts page renewal logic, users must now increase salary before they can increase duration
- The +duration button is disabled if salary has not been increased from its current value
- Exception: "spalma" cases (contracts with duration=1 and canSpalmare=true) which allow extending duration without salary increase per existing business rules
- Tooltip message "Aumenta prima l'ingaggio per estendere la durata" shown when the +duration button is disabled due to this new rule

## Test plan
- [ ] Open Contracts page with existing contracts in CONTRATTI phase
- [ ] Verify that +duration button is disabled when salary equals current salary
- [ ] Verify that +duration button is enabled after increasing salary above current
- [ ] Verify that "spalma" contracts (duration=1) can still increase duration without salary increase
- [ ] Verify tooltip appears on hover when +duration button is disabled

Closes #207

Generated with [Claude Code](https://claude.ai/code)