### PR TITLE
feat(#208): add Patch Notes page for alpha test users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ const ForgotPassword = lazy(() => import('./pages/ForgotPassword').then(m => ({ 
 const ResetPassword = lazy(() => import('./pages/ResetPassword').then(m => ({ default: m.ResetPassword })))
 const InviteDetail = lazy(() => import('./pages/InviteDetail').then(m => ({ default: m.InviteDetail })))
 const Rules = lazy(() => import('./pages/Rules').then(m => ({ default: m.Rules })))
+const PatchNotes = lazy(() => import('./pages/PatchNotes').then(m => ({ default: m.PatchNotes })))
 
 // Loading component per autenticazione
 function LoadingScreen() {
@@ -198,6 +199,7 @@ function createLeagueNavigator(navigate: ReturnType<typeof useNavigate>, leagueI
       case 'prophecies': navigate(`/leagues/${lid}/prophecies`); break
       case 'playerStats': navigate(`/leagues/${lid}/stats`); break
       case 'financials': navigate(`/leagues/${lid}/financials`); break
+      case 'patchNotes': navigate(`/leagues/${lid}/patch-notes`); break
       case 'superadmin':
         if (params?.tab) navigate(`/superadmin?tab=${params.tab}`)
         else navigate('/superadmin')
@@ -375,6 +377,15 @@ function LeagueFinancialsWrapper() {
 
   if (!leagueId) return <Navigate to="/dashboard" replace />
   return <LeagueFinancials leagueId={leagueId} onNavigate={onNavigate} />
+}
+
+function PatchNotesWrapper() {
+  const navigate = useNavigate()
+  const { leagueId } = useParams<{ leagueId: string }>()
+  const onNavigate = useCallback(createLeagueNavigator(navigate, leagueId), [navigate, leagueId])
+
+  if (!leagueId) return <Navigate to="/dashboard" replace />
+  return <PatchNotes leagueId={leagueId} onNavigate={onNavigate} />
 }
 
 function SuperAdminWrapper() {
@@ -591,6 +602,13 @@ function AppRoutes() {
         <ProtectedRoute>
           <Suspense fallback={<PageLoader />}>
             <PrizePhasePageWrapper />
+          </Suspense>
+        </ProtectedRoute>
+      } />
+      <Route path="/leagues/:leagueId/patch-notes" element={
+        <ProtectedRoute>
+          <Suspense fallback={<PageLoader />}>
+            <PatchNotesWrapper />
           </Suspense>
         </ProtectedRoute>
       } />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -116,6 +116,11 @@ const MenuIcons = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
     </svg>
   ),
+  patchNotes: (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+    </svg>
+  ),
 }
 
 // League menu items configuration
@@ -129,6 +134,7 @@ const LEAGUE_MENU_ITEMS = [
   { key: 'financials', label: 'Finanze', adminOnly: false, icon: 'financials' },
   { key: 'history', label: 'Storico', adminOnly: false, icon: 'history' },
   { key: 'prophecies', label: 'Profezie', adminOnly: false, icon: 'prophecy' },
+  { key: 'patchNotes', label: 'Patch Notes', adminOnly: false, icon: 'patchNotes' },
 ]
 
 // Get page display name for breadcrumbs (should match menu labels)
@@ -148,6 +154,7 @@ function getPageDisplayName(page: string): string {
     rubata: 'Rubata',
     'strategie-rubata': 'Giocatori',
     financials: 'Finanze',
+    patchNotes: 'Patch Notes',
   }
   return pageNames[page] || page
 }

--- a/src/pages/PatchNotes.tsx
+++ b/src/pages/PatchNotes.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from 'react'
+import { leagueApi } from '../services/api'
+import { Navigation } from '../components/Navigation'
+
+interface PatchNote {
+  id: string
+  version: string
+  date: string
+  title: string
+  description: string
+  type: 'feature' | 'fix' | 'improvement'
+  issueNumber?: number
+}
+
+interface PatchNotesProps {
+  leagueId: string
+  onNavigate: (page: string, params?: Record<string, string>) => void
+}
+
+// Hardcoded patch notes - in the future this could come from an API
+const PATCH_NOTES: PatchNote[] = [
+  {
+    id: '1',
+    version: '1.x',
+    date: '2026-01-30',
+    title: 'Pagina Patch Notes',
+    description: 'Aggiunta nuova pagina per visualizzare le note di rilascio e gli aggiornamenti dell\'applicazione.',
+    type: 'feature',
+    issueNumber: 208,
+  },
+  {
+    id: '2',
+    version: '1.x',
+    date: '2026-01-29',
+    title: 'Richiesta aumento ingaggio prima di estendere durata',
+    description: 'Ora e\' possibile richiedere un aumento di ingaggio prima di procedere con l\'estensione della durata del contratto.',
+    type: 'feature',
+    issueNumber: 207,
+  },
+  {
+    id: '3',
+    version: '1.x',
+    date: '2026-01-28',
+    title: 'Eta e rating in tabella Contratti',
+    description: 'Aggiunte colonne per visualizzare eta e rating dei giocatori direttamente nella tabella dei contratti.',
+    type: 'improvement',
+    issueNumber: 206,
+  },
+  {
+    id: '4',
+    version: '1.x',
+    date: '2026-01-27',
+    title: 'Modale statistiche giocatore nei Contratti',
+    description: 'Implementata modale per visualizzare le statistiche dettagliate del giocatore direttamente dalla pagina Contratti.',
+    type: 'feature',
+    issueNumber: 205,
+  },
+  {
+    id: '5',
+    version: '1.x',
+    date: '2026-01-26',
+    title: 'Integrazione statistiche API-Football',
+    description: 'Integrazione con API-Football per recuperare e visualizzare statistiche aggiornate dei giocatori.',
+    type: 'feature',
+    issueNumber: 159,
+  },
+  {
+    id: '6',
+    version: '1.x',
+    date: '2026-01-25',
+    title: 'Sistema KEEP/RELEASE per giocatori usciti',
+    description: 'Aggiunto sistema per gestire le decisioni KEEP/RELEASE per i giocatori che lasciano il campionato.',
+    type: 'feature',
+    issueNumber: 158,
+  },
+]
+
+const typeConfig = {
+  feature: {
+    label: 'Nuova Funzionalita',
+    color: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+      </svg>
+    ),
+  },
+  fix: {
+    label: 'Bug Fix',
+    color: 'bg-red-500/20 text-red-400 border-red-500/30',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+      </svg>
+    ),
+  },
+  improvement: {
+    label: 'Miglioramento',
+    color: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+      </svg>
+    ),
+  },
+}
+
+export function PatchNotes({ leagueId, onNavigate }: PatchNotesProps) {
+  const [isLeagueAdmin, setIsLeagueAdmin] = useState(false)
+  const [leagueName, setLeagueName] = useState<string>()
+  const [teamName, setTeamName] = useState<string>()
+
+  useEffect(() => {
+    if (leagueId) {
+      loadLeagueInfo()
+    }
+  }, [leagueId])
+
+  async function loadLeagueInfo() {
+    const response = await leagueApi.getById(leagueId)
+    if (response.success && response.data) {
+      const data = response.data as {
+        name: string
+        userMembership?: { role: string; teamName?: string }
+      }
+      setIsLeagueAdmin(data.userMembership?.role === 'ADMIN')
+      setLeagueName(data.name)
+      setTeamName(data.userMembership?.teamName)
+    }
+  }
+
+  function formatDate(dateString: string): string {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('it-IT', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-dark-300">
+      <Navigation
+        currentPage="patchNotes"
+        leagueId={leagueId}
+        leagueName={leagueName}
+        teamName={teamName}
+        isLeagueAdmin={isLeagueAdmin}
+        onNavigate={onNavigate}
+      />
+
+      <main className="max-w-4xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-purple-500 to-purple-700 flex items-center justify-center">
+              <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-white">Patch Notes</h1>
+              <p className="text-sm text-gray-400">Cronologia degli aggiornamenti dell'applicazione</p>
+            </div>
+          </div>
+
+          {/* Alpha Test Badge */}
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-amber-500/10 border border-amber-500/30 rounded-lg mt-2">
+            <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
+            <span className="text-xs text-amber-400 font-medium">Alpha Test</span>
+            <span className="text-xs text-gray-500">Questa e' una versione di test - segnala eventuali problemi!</span>
+          </div>
+        </div>
+
+        {/* Patch Notes List */}
+        <div className="space-y-4">
+          {PATCH_NOTES.map((patch) => {
+            const config = typeConfig[patch.type]
+            return (
+              <div
+                key={patch.id}
+                className="bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden hover:border-purple-500/30 transition-colors"
+              >
+                {/* Header */}
+                <div className="px-4 py-3 bg-surface-300/50 border-b border-surface-50/20 flex items-center justify-between flex-wrap gap-2">
+                  <div className="flex items-center gap-3">
+                    {/* Version Badge */}
+                    <span className="px-2.5 py-1 bg-purple-500/20 text-purple-400 text-xs font-mono font-semibold rounded-lg border border-purple-500/30">
+                      {patch.version}
+                    </span>
+
+                    {/* Type Badge */}
+                    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-lg border ${config.color}`}>
+                      {config.icon}
+                      {config.label}
+                    </span>
+
+                    {/* Issue Number */}
+                    {patch.issueNumber && (
+                      <span className="text-xs text-gray-500 font-mono">
+                        #{patch.issueNumber}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Date */}
+                  <span className="text-xs text-gray-400">
+                    {formatDate(patch.date)}
+                  </span>
+                </div>
+
+                {/* Content */}
+                <div className="px-4 py-4">
+                  <h3 className="text-lg font-semibold text-white mb-2">
+                    {patch.title}
+                  </h3>
+                  <p className="text-sm text-gray-400 leading-relaxed">
+                    {patch.description}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-8 text-center">
+          <p className="text-xs text-gray-500">
+            Hai suggerimenti o hai trovato un bug? Contatta l'amministratore della lega.
+          </p>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default PatchNotes


### PR DESCRIPTION
## Summary
- Adds a new **Patch Notes** page accessible within the league context
- Displays application changelog with recent features, fixes, and improvements
- Helps alpha testers track new updates and provides context about changes
- Includes hardcoded patch notes for recent issues (#205, #206, #207, #208, etc.)

## Changes
- Created `src/pages/PatchNotes.tsx` - New page component with dark theme styling
- Updated `src/App.tsx` - Added lazy import, wrapper, and route for `/leagues/:leagueId/patch-notes`
- Updated `src/components/Navigation.tsx` - Added menu item and icon for Patch Notes

## Test plan
- [ ] Navigate to a league and verify "Patch Notes" appears in the navigation menu
- [ ] Click on Patch Notes and verify the page loads correctly
- [ ] Verify all patch notes are displayed with proper formatting (version, type badge, date, title, description)
- [ ] Verify the Alpha Test badge is visible
- [ ] Test on mobile view to ensure responsive layout

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)