### PR TITLE
feat: Sprint 5 API routes + frontend admin UI

### DIFF
--- a/src/api/routes/svincolati.ts
+++ b/src/api/routes/svincolati.ts
@@ -32,6 +32,9 @@ import {
   forceAllSvincolatiFinished,
   // Connection tracking
   registerSvincolatiHeartbeat,
+  // Admin pause/resume
+  pauseSvincolati,
+  resumeSvincolati,
 } from '../../services/svincolati.service'
 import { simulateBotBidding, getBotMembers } from '../../services/bot.service'
 import { authMiddleware } from '../middleware/auth'
@@ -622,6 +625,42 @@ router.post('/leagues/:leagueId/svincolati/heartbeat', authMiddleware, async (re
     res.json({ success: true })
   } catch (error) {
     console.error('Svincolati heartbeat error:', error)
+    res.status(500).json({ success: false, message: 'Errore interno del server' })
+  }
+})
+
+// ==================== ADMIN: PAUSE / RESUME ====================
+
+router.post('/:leagueId/svincolati/pause', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { leagueId } = req.params
+    const result = await pauseSvincolati(leagueId, req.user!.userId)
+
+    if (!result.success) {
+      res.status(result.message === 'Non autorizzato' ? 403 : 400).json(result)
+      return
+    }
+
+    res.json(result)
+  } catch (error) {
+    console.error('Pause svincolati error:', error)
+    res.status(500).json({ success: false, message: 'Errore interno del server' })
+  }
+})
+
+router.post('/:leagueId/svincolati/resume', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { leagueId } = req.params
+    const result = await resumeSvincolati(leagueId, req.user!.userId)
+
+    if (!result.success) {
+      res.status(result.message === 'Non autorizzato' ? 403 : 400).json(result)
+      return
+    }
+
+    res.json(result)
+  } catch (error) {
+    console.error('Resume svincolati error:', error)
     res.status(500).json({ success: false, message: 'Errore interno del server' })
   }
 })

--- a/src/pages/AuctionRoom.tsx
+++ b/src/pages/AuctionRoom.tsx
@@ -933,6 +933,26 @@ export function AuctionRoom({ sessionId, leagueId, onNavigate }: AuctionRoomProp
     }
   }
 
+  async function handlePauseAuction() {
+    setError('')
+    const res = await auctionApi.pauseAuction(leagueId)
+    if (res.success) {
+      loadCurrentAuction()
+    } else {
+      setError(res.message || 'Errore')
+    }
+  }
+
+  async function handleResumeAuction() {
+    setError('')
+    const res = await auctionApi.resumeAuction(leagueId)
+    if (res.success) {
+      loadCurrentAuction()
+    } else {
+      setError(res.message || 'Errore')
+    }
+  }
+
   async function handleCompleteAllSlots() {
     if (!sessionId) return
     if (!confirm('Sei sicuro di voler completare l\'asta riempiendo tutti gli slot di tutti i Direttori Generali?')) return
@@ -1593,6 +1613,31 @@ export function AuctionRoom({ sessionId, leagueId, onNavigate }: AuctionRoomProp
                       ))}
                     </div>
                   </div>
+                  {/* Pause / Resume */}
+                  {auction && (
+                    <div className="pt-2 border-t border-surface-50/20">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handlePauseAuction}
+                        className="w-full text-xs border-warning-500/50 text-warning-400 hover:bg-warning-500/10"
+                      >
+                        Pausa Asta
+                      </Button>
+                    </div>
+                  )}
+                  {!auction && firstMarketStatus?.currentPhase === 'PAUSED' && (
+                    <div className="pt-2 border-t border-surface-50/20">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleResumeAuction}
+                        className="w-full text-xs border-secondary-500/50 text-secondary-400 hover:bg-secondary-500/10"
+                      >
+                        Riprendi Asta
+                      </Button>
+                    </div>
+                  )}
                   <div className="pt-2 border-t border-surface-50/20 space-y-2">
                     <p className="text-xs text-accent-500 font-bold uppercase">Test Mode</p>
                     <Button size="sm" variant="outline" onClick={handleBotNominate} className="w-full text-xs border-warning-500/50 text-warning-400 hover:bg-warning-500/10">

--- a/src/pages/Svincolati.tsx
+++ b/src/pages/Svincolati.tsx
@@ -782,6 +782,34 @@ export function Svincolati({ leagueId, onNavigate }: SvincolatiProps) {
     }
   }
 
+  // ========== PAUSE / RESUME ==========
+
+  async function handlePause() {
+    setError('')
+    setIsSubmitting(true)
+
+    const res = await svincolatiApi.pause(leagueId)
+    if (res.success) {
+      loadBoard()
+    } else {
+      setError(res.message || 'Errore')
+    }
+    setIsSubmitting(false)
+  }
+
+  async function handleResume() {
+    setError('')
+    setIsSubmitting(true)
+
+    const res = await svincolatiApi.resume(leagueId)
+    if (res.success) {
+      loadBoard()
+    } else {
+      setError(res.message || 'Errore')
+    }
+    setIsSubmitting(false)
+  }
+
   // ========== TIMER ==========
 
   async function handleSetTimer() {
@@ -1251,6 +1279,34 @@ export function Svincolati({ leagueId, onNavigate }: SvincolatiProps) {
                       ))}
                     </div>
                   </div>
+
+                  {/* Pause / Resume */}
+                  {(state === 'AUCTION' || state === 'NOMINATION' || state === 'READY_CHECK') && (
+                    <div className="pt-2 border-t border-surface-50/20">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handlePause}
+                        disabled={isSubmitting}
+                        className="w-full text-xs border-warning-500/50 text-warning-400 hover:bg-warning-500/10"
+                      >
+                        Pausa
+                      </Button>
+                    </div>
+                  )}
+                  {state === 'PAUSED' && (
+                    <div className="pt-2 border-t border-surface-50/20">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleResume}
+                        disabled={isSubmitting}
+                        className="w-full text-xs border-secondary-500/50 text-secondary-400 hover:bg-secondary-500/10"
+                      >
+                        Riprendi
+                      </Button>
+                    </div>
+                  )}
 
                   {/* Test Mode */}
                   <div className="pt-2 border-t border-surface-50/20 space-y-2">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -592,6 +592,27 @@ export const auctionApi = {
     request(`/api/auctions/${auctionId}/force-all-ready-resume`, {
       method: 'POST',
     }),
+
+  // Admin: Pause/Resume auction timer
+  pauseAuction: (leagueId: string) =>
+    request(`/api/leagues/${leagueId}/auctions/pause`, { method: 'POST' }),
+
+  resumeAuction: (leagueId: string) =>
+    request(`/api/leagues/${leagueId}/auctions/resume`, { method: 'POST' }),
+
+  // Admin: Cancel active auction
+  cancelActiveAuction: (leagueId: string, auctionId: string) =>
+    request(`/api/leagues/${leagueId}/auctions/cancel`, {
+      method: 'POST',
+      body: JSON.stringify({ auctionId }),
+    }),
+
+  // Admin: Rectify completed auction
+  rectifyTransaction: (leagueId: string, auctionId: string, newWinnerId?: string, newPrice?: number) =>
+    request(`/api/leagues/${leagueId}/auctions/rectify`, {
+      method: 'POST',
+      body: JSON.stringify({ auctionId, newWinnerId, newPrice }),
+    }),
 }
 
 // Contract API
@@ -1143,6 +1164,13 @@ export const svincolatiApi = {
       method: 'POST',
       body: JSON.stringify({ memberId }),
     }),
+
+  // Admin: Pause/Resume svincolati timer
+  pause: (leagueId: string) =>
+    request(`/api/leagues/${leagueId}/svincolati/pause`, { method: 'POST' }),
+
+  resume: (leagueId: string) =>
+    request(`/api/leagues/${leagueId}/svincolati/resume`, { method: 'POST' }),
 }
 
 // Admin API


### PR DESCRIPTION
## Summary
- Add API routes for Sprint 5 admin functions (pause/resume/cancel/rectify)
- Add frontend UI components (pause/resume buttons in AuctionRoom + Svincolati)
- Add frontend API client methods for all new endpoints

## Changes
- `src/api/routes/auctions.ts` - 4 new admin routes
- `src/api/routes/svincolati.ts` - 2 new admin routes
- `src/pages/AuctionRoom.tsx` - Pause/Resume buttons in admin controls
- `src/pages/Svincolati.tsx` - Pause/Resume handlers + buttons
- `src/services/api.ts` - 6 new API client methods

## Test plan
- [x] 105 unit tests passing (Sprint 1-5)
- [x] TypeScript compilation clean (only pre-existing test file errors)
- [ ] E2E tests with dev server
- [ ] Integration tests with Docker/PostgreSQL

Generated with [Claude Code](https://claude.com/claude-code)