### PR TITLE
feat: Sprint Combinato 2 - DataTable, lucide-react, mobile nav, BottomSheet filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,14 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700&family=Oswald:wght@500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Fantacontratti - Piattaforma per la gestione dei mercati del fantacalcio dinastico" />
+    <meta name="theme-color" content="#1a1d24" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Fantacontratti" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <title>Fantacontratti</title>
     <!-- Default theme CSS variables (Sleeper Dark) - prevents flash of unstyled content -->
     <style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cors": "^2.8.5",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
+        "lucide-react": "^0.563.0",
         "multer": "^2.0.2",
         "nanoid": "^5.1.6",
         "nodemailer": "^7.0.12",
@@ -7131,6 +7132,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.563.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cors": "^2.8.5",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
+    "lucide-react": "^0.563.0",
     "multer": "^2.0.2",
     "nanoid": "^5.1.6",
     "nodemailer": "^7.0.12",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Fantacontratti",
+  "short_name": "FC",
+  "description": "Piattaforma per la gestione dei mercati del fantacalcio dinastico",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1d24",
+  "theme_color": "#4ade80",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { SpeedInsights } from '@vercel/speed-insights/react'
 import { AuthProvider, useAuth } from './hooks/useAuth'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { ScrollToTop } from './components/ui/ScrollToTop'
+import { BottomNavBar } from './components/BottomNavBar'
 
 // Pagine critiche - import statico (usate al primo caricamento)
 import { Login } from './pages/Login'
@@ -662,12 +663,26 @@ function AppRoutes() {
   )
 }
 
+/** Spacer to prevent content from hiding behind BottomNavBar on mobile */
+function BottomNavSpacer() {
+  const location = useLocation()
+  const isLeague = /^\/leagues\/[^/]+/.test(location.pathname)
+  if (!isLeague) return null
+  return <div className="md:hidden h-16" />
+}
+
 function App() {
+  const handleMobileMenuOpen = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('open-mobile-menu'))
+  }, [])
+
   return (
     <BrowserRouter>
       <ThemeProvider>
         <AuthProvider>
           <AppRoutes />
+          <BottomNavSpacer />
+          <BottomNavBar onMenuOpen={handleMobileMenuOpen} />
           <ScrollToTop />
           <SpeedInsights />
         </AuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, useNavigate, useParams, useSear
 import { SpeedInsights } from '@vercel/speed-insights/react'
 import { AuthProvider, useAuth } from './hooks/useAuth'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { ScrollToTop } from './components/ui/ScrollToTop'
 
 // Pagine critiche - import statico (usate al primo caricamento)
 import { Login } from './pages/Login'
@@ -667,6 +668,7 @@ function App() {
       <ThemeProvider>
         <AuthProvider>
           <AppRoutes />
+          <ScrollToTop />
           <SpeedInsights />
         </AuthProvider>
       </ThemeProvider>

--- a/src/components/AuctionTimer.tsx
+++ b/src/components/AuctionTimer.tsx
@@ -106,7 +106,7 @@ export function AuctionTimer({
   // === VERSIONE COMPATTA (per sticky mobile) ===
   if (compact) {
     return (
-      <div className={`flex items-center gap-2 ${className}`}>
+      <div className={`flex items-center gap-2 ${className}`} role="timer" aria-live="polite" aria-label={`${timeLeft} secondi rimanenti`}>
         {/* Mini cerchio progress */}
         <div className="relative">
           <svg width={size} height={size} className="transform -rotate-90">
@@ -148,8 +148,10 @@ export function AuctionTimer({
   }
 
   // === VERSIONE FULL (per desktop e sezione principale) ===
+  const statusLabel = timeLeft <= 5 ? 'Ultimi secondi' : timeLeft <= 10 ? 'Affrettati' : 'Tempo OK'
+
   return (
-    <div className={`relative ${className}`}>
+    <div className={`relative ${className}`} role="timer" aria-live="assertive" aria-label={`Timer asta: ${timeLeft} secondi rimanenti. ${statusLabel}`}>
       {/* Container principale con effetto glow */}
       <div
         className={`

--- a/src/components/BottomNavBar.tsx
+++ b/src/components/BottomNavBar.tsx
@@ -1,0 +1,125 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Home, Zap, Users, CircleDollarSign, Menu } from 'lucide-react'
+
+/**
+ * Mobile bottom navigation bar — visible only <768px.
+ * 5 tabs: Home, Asta, Rosa, Finanze, Menu.
+ * Hides on scroll-down, shows on scroll-up.
+ * Only renders inside a league context (/leagues/:leagueId/...).
+ */
+export function BottomNavBar({ onMenuOpen }: { onMenuOpen: () => void }) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [visible, setVisible] = useState(true)
+  const lastScrollY = useRef(0)
+
+  // Extract leagueId from URL
+  const leagueMatch = location.pathname.match(/^\/leagues\/([^/]+)/)
+  const leagueId = leagueMatch?.[1]
+
+  // Detect current page from URL
+  const pathAfterLeague = leagueMatch ? location.pathname.slice(leagueMatch[0].length) : ''
+  const currentTab = getActiveTab(pathAfterLeague)
+
+  // Detect auction
+  const isInAuction = pathAfterLeague.startsWith('/auction')
+
+  // Scroll hide/show
+  const handleScroll = useCallback(() => {
+    const currentY = window.scrollY
+    if (currentY > lastScrollY.current + 10 && currentY > 100) {
+      setVisible(false) // scrolling down
+    } else if (currentY < lastScrollY.current - 10) {
+      setVisible(true) // scrolling up
+    }
+    lastScrollY.current = currentY
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [handleScroll])
+
+  // Always show on route change
+  useEffect(() => {
+    setVisible(true)
+  }, [location.pathname])
+
+  // Only show inside league context
+  if (!leagueId) return null
+
+  const tabs: TabDef[] = [
+    { key: 'home', label: 'Home', icon: Home, path: `/leagues/${leagueId}` },
+    { key: 'asta', label: 'Asta', icon: Zap, path: `/leagues/${leagueId}/auction`, badge: isInAuction ? 'LIVE' : undefined },
+    { key: 'rosa', label: 'Rosa', icon: Users, path: `/leagues/${leagueId}/strategie-rubata` },
+    { key: 'finanze', label: 'Finanze', icon: CircleDollarSign, path: `/leagues/${leagueId}/financials` },
+    { key: 'menu', label: 'Menu', icon: Menu, path: '' },
+  ]
+
+  return (
+    <nav
+      className={`md:hidden fixed bottom-0 left-0 right-0 z-40 bg-surface-200/95 backdrop-blur-md border-t border-surface-50/20 transition-transform duration-300 ${visible ? 'translate-y-0' : 'translate-y-full'}`}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      aria-label="Navigazione principale"
+    >
+      <div className="flex items-stretch justify-around h-14">
+        {tabs.map((tab) => {
+          const isActive = tab.key === currentTab
+          const Icon = tab.icon
+
+          return (
+            <button
+              key={tab.key}
+              onClick={() => {
+                if (tab.key === 'menu') {
+                  onMenuOpen()
+                } else {
+                  navigate(tab.path)
+                }
+              }}
+              className={`relative flex-1 flex flex-col items-center justify-center gap-0.5 transition-colors ${
+                isActive
+                  ? 'text-primary-400'
+                  : 'text-gray-500 active:text-gray-300'
+              }`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <div className="relative">
+                <Icon size={20} />
+                {tab.badge && (
+                  <span className="absolute -top-1.5 -right-3 px-1 py-0 text-[8px] font-bold bg-danger-500 text-white rounded-full leading-tight animate-pulse">
+                    {tab.badge}
+                  </span>
+                )}
+              </div>
+              <span className="text-[10px] font-medium leading-none">{tab.label}</span>
+              {isActive && (
+                <span className="absolute top-0 left-1/2 -translate-x-1/2 w-8 h-0.5 bg-primary-400 rounded-full" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}
+
+interface TabDef {
+  key: string
+  label: string
+  icon: React.ComponentType<{ size: number }>
+  path: string
+  badge?: string
+}
+
+/** Map URL path segment to active tab key */
+function getActiveTab(pathAfterLeague: string): string {
+  if (!pathAfterLeague || pathAfterLeague === '/') return 'home'
+  if (pathAfterLeague.startsWith('/auction') || pathAfterLeague.startsWith('/rubata') || pathAfterLeague.startsWith('/svincolati')) return 'asta'
+  if (pathAfterLeague.startsWith('/strategie-rubata') || pathAfterLeague.startsWith('/rose') || pathAfterLeague.startsWith('/all-players')) return 'rosa'
+  if (pathAfterLeague.startsWith('/financials') || pathAfterLeague.startsWith('/contracts') || pathAfterLeague.startsWith('/movements') || pathAfterLeague.startsWith('/history')) return 'finanze'
+  return 'home' // default
+}
+
+export default BottomNavBar

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -269,7 +269,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
           <div className="flex items-center gap-2">
             {/* Mobile menu button - a sinistra */}
             <button
-              className="lg:hidden text-gray-400 hover:text-white p-2 hover:bg-surface-300/50 rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-400/50"
+              className="lg:hidden text-gray-400 hover:text-white p-2 w-11 h-11 flex items-center justify-center hover:bg-surface-300/50 rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-400/50"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               data-testid="mobile-menu-toggle"
               aria-expanded={mobileMenuOpen}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,6 +7,12 @@ import { PendingInvites } from './PendingInvites'
 import { FeedbackBadge } from './FeedbackBadge'
 import { pusherClient } from '../services/pusher.client'
 import { ThemeSelector, ThemeButton } from './ThemeSelector'
+import {
+  Home, Settings, User, Users, UserPlus, Clock, Lightbulb,
+  ArrowLeft, Trophy, CircleUserRound, BookOpen, CloudUpload,
+  CircleDollarSign, ChevronRight, ChevronDown, ShieldCheck,
+  BarChart3, FileText, MessageSquare, Menu, X, Star, LogOut, Palette,
+} from 'lucide-react'
 
 interface NavigationProps {
   currentPage: string
@@ -19,114 +25,30 @@ interface NavigationProps {
   onNavigate: (page: string, params?: Record<string, string>) => void
 }
 
-// SVG Icons for menu items
+// Icons for menu items — using lucide-react (tree-shakeable)
+const ICON_SIZE = 16 // w-4 h-4
 const MenuIcons = {
-  dashboard: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-    </svg>
-  ),
-  admin: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    </svg>
-  ),
-  roster: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-    </svg>
-  ),
-  allRosters: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-    </svg>
-  ),
-  svincolati: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
-    </svg>
-  ),
-  history: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-  ),
-  prophecy: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-    </svg>
-  ),
-  back: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-    </svg>
-  ),
-  leagues: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-    </svg>
-  ),
-  profile: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-  ),
-  rules: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-    </svg>
-  ),
-  upload: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-    </svg>
-  ),
-  players: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-    </svg>
-  ),
-  users: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-    </svg>
-  ),
-  home: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-    </svg>
-  ),
-  financials: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-  ),
-  chevronRight: (
-    <svg className="w-3 h-3 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-    </svg>
-  ),
-  strategy: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-    </svg>
-  ),
-  stats: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-    </svg>
-  ),
-  patchNotes: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-    </svg>
-  ),
-  feedbackHub: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-    </svg>
-  ),
+  dashboard: <Home size={ICON_SIZE} />,
+  admin: <Settings size={ICON_SIZE} />,
+  roster: <User size={ICON_SIZE} />,
+  allRosters: <Users size={ICON_SIZE} />,
+  svincolati: <UserPlus size={ICON_SIZE} />,
+  history: <Clock size={ICON_SIZE} />,
+  prophecy: <Lightbulb size={ICON_SIZE} />,
+  back: <ArrowLeft size={ICON_SIZE} />,
+  leagues: <Trophy size={ICON_SIZE} />,
+  profile: <CircleUserRound size={ICON_SIZE} />,
+  rules: <BookOpen size={ICON_SIZE} />,
+  upload: <CloudUpload size={ICON_SIZE} />,
+  players: <Users size={ICON_SIZE} />,
+  users: <Users size={ICON_SIZE} />,
+  home: <Home size={ICON_SIZE} />,
+  financials: <CircleDollarSign size={ICON_SIZE} />,
+  chevronRight: <ChevronRight size={12} className="text-gray-500" />,
+  strategy: <ShieldCheck size={ICON_SIZE} />,
+  stats: <BarChart3 size={ICON_SIZE} />,
+  patchNotes: <FileText size={ICON_SIZE} />,
+  feedbackHub: <MessageSquare size={ICON_SIZE} />,
 }
 
 // League menu items configuration
@@ -233,6 +155,13 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
     return () => document.removeEventListener('keydown', handleEscape)
   }, [])
 
+  // Listen for BottomNavBar "Menu" tap (custom event)
+  useEffect(() => {
+    const handleOpenMobileMenu = () => setMobileMenuOpen(true)
+    window.addEventListener('open-mobile-menu', handleOpenMobileMenu)
+    return () => window.removeEventListener('open-mobile-menu', handleOpenMobileMenu)
+  }, [])
+
   // Handle keyboard navigation for profile dropdown
   const handleProfileKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -275,13 +204,11 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
               aria-expanded={mobileMenuOpen}
               aria-label={mobileMenuOpen ? 'Chiudi menu' : 'Apri menu'}
             >
-              <svg className={`w-6 h-6 transition-transform duration-300 ${mobileMenuOpen ? 'rotate-90' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                {mobileMenuOpen ? (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                ) : (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                )}
-              </svg>
+              {mobileMenuOpen ? (
+                <X size={24} className={`transition-transform duration-300 ${mobileMenuOpen ? 'rotate-90' : ''}`} />
+              ) : (
+                <Menu size={24} className="transition-transform duration-300" />
+              )}
             </button>
 
             {/* Logo */}
@@ -323,9 +250,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
               {/* Admin Badge - shown when user is league admin */}
               {leagueId && isLeagueAdmin && (
                 <div className="flex items-center gap-1.5 px-2.5 py-1 bg-gradient-to-r from-accent-500/20 to-accent-600/10 border border-accent-500/30 rounded-lg shadow-sm" data-testid="admin-badge">
-                  <svg className="w-3.5 h-3.5 text-accent-400" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M10 1l2.928 6.856L20 8.485l-5 4.428 1.325 7.087L10 16.5 3.675 20l1.325-7.087-5-4.428 7.072-.629L10 1z" clipRule="evenodd" />
-                  </svg>
+                  <Star size={14} className="text-accent-400" fill="currentColor" />
                   <span className="text-[10px] font-semibold text-accent-400 uppercase tracking-wider">Admin</span>
                 </div>
               )}
@@ -471,9 +396,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
                   className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-400 hover:text-white bg-surface-300/50 hover:bg-surface-300 rounded-lg transition-all duration-200 hover:shadow-md group"
                   data-testid="back-to-leagues"
                 >
-                  <svg className="w-4 h-4 transform group-hover:-translate-x-0.5 transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                  </svg>
+                  <ArrowLeft size={16} className="transform group-hover:-translate-x-0.5 transition-transform duration-200" />
                   Leghe
                 </button>
               </>
@@ -505,9 +428,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
                     {teamName || user?.username}
                   </p>
                 </div>
-                <svg className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${profileDropdownOpen ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
+                <ChevronDown size={16} className={`text-gray-400 transition-transform duration-200 ${profileDropdownOpen ? 'rotate-180' : ''}`} />
               </button>
 
               {/* Profile Dropdown Menu */}
@@ -590,9 +511,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
                     data-testid="logout-button-dropdown"
                     role="menuitem"
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                    </svg>
+                    <LogOut size={16} />
                     Esci
                   </button>
                 </div>
@@ -657,9 +576,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
               className="p-2 text-gray-400 hover:text-white rounded-lg bg-white/10"
               aria-label="Chiudi menu"
             >
-              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X size={24} />
             </button>
           </div>
 
@@ -801,9 +718,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
                 className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-gray-300 hover:bg-surface-300/60 hover:text-white transition-colors"
                 data-testid="mobile-theme-selector"
               >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
-                </svg>
+                <Palette size={20} />
                 Personalizza Tema
               </button>
             </div>
@@ -815,9 +730,7 @@ export function Navigation({ currentPage, leagueId, leagueName, teamName, isLeag
                 className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-danger-400 hover:bg-danger-500/10 transition-colors"
                 data-testid="mobile-logout"
               >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                </svg>
+                <LogOut size={20} />
                 Esci
               </button>
             </div>
@@ -859,9 +772,7 @@ function NavButton({ label, active, onClick, accent, highlight, large, isAdmin, 
   const getIcon = () => {
     if (isAdmin) {
       return (
-        <svg className="w-3.5 h-3.5 transition-transform duration-200 group-hover:scale-110" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 1l2.928 6.856L20 8.485l-5 4.428 1.325 7.087L10 16.5 3.675 20l1.325-7.087-5-4.428 7.072-.629L10 1z" clipRule="evenodd" />
-        </svg>
+        <Star size={14} fill="currentColor" className="transition-transform duration-200 group-hover:scale-110" />
       )
     }
     if (iconKey && MenuIcons[iconKey as keyof typeof MenuIcons]) {
@@ -958,18 +869,10 @@ function MobileNavButton({ label, active, onClick, accent, highlight, icon, isAd
       return <span className="w-5 h-5 flex items-center justify-center">{iconElement}</span>
     }
     if (icon === 'back') {
-      return (
-        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-        </svg>
-      )
+      return <ArrowLeft size={20} />
     }
     if ((highlight || isAdmin) && !iconElement) {
-      return (
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 1l2.928 6.856L20 8.485l-5 4.428 1.325 7.087L10 16.5 3.675 20l1.325-7.087-5-4.428 7.072-.629L10 1z" clipRule="evenodd" />
-        </svg>
-      )
+      return <Star size={20} fill="currentColor" />
     }
     if (iconElement) {
       return <span className="w-5 h-5 flex items-center justify-center">{iconElement}</span>

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -168,6 +168,7 @@ export function Notifications({ leagueId, isAdmin, onNavigate }: NotificationsPr
         onClick={() => setIsOpen(!isOpen)}
         className="relative p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-surface-300/50"
         title="Notifiche"
+        aria-label="Notifiche"
       >
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />

--- a/src/components/SearchLeaguesModal.tsx
+++ b/src/components/SearchLeaguesModal.tsx
@@ -137,6 +137,8 @@ export function SearchLeaguesModal({ isOpen, onClose, onNavigate }: SearchLeague
               <input
                 ref={inputRef}
                 type="text"
+                inputMode="search"
+                enterKeyHint="search"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Nome lega, codice invito, admin o membro..."

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTheme, styleThemes, themeCategories, fonts, type FontKey } from '../contexts/ThemeContext'
+import { X, Check, Palette } from 'lucide-react'
 
 interface ThemeSelectorProps {
   isOpen: boolean
@@ -37,9 +38,7 @@ export function ThemeSelector({ isOpen, onClose }: ThemeSelectorProps) {
             className="p-2 rounded-lg hover:bg-theme-hover text-theme-muted hover:text-theme-text transition-colors"
             aria-label="Chiudi selettore tema"
           >
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X size={24} />
           </button>
         </div>
 
@@ -133,9 +132,7 @@ export function ThemeSelector({ isOpen, onClose }: ThemeSelectorProps) {
                   </div>
                   {themeId === theme.id && (
                     <div className="w-6 h-6 rounded-full bg-theme-primary flex items-center justify-center">
-                      <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                      </svg>
+                      <Check size={16} className="text-white" strokeWidth={3} />
                     </div>
                   )}
                 </div>
@@ -190,9 +187,7 @@ export function ThemeButton({ onClick }: { onClick: () => void }) {
       ) : (
         <div className="w-5 h-5 rounded" style={{ backgroundColor: theme.vars['--primary'] }} />
       )}
-      <svg className="w-4 h-4 text-theme-muted group-hover:text-theme-primary transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
-      </svg>
+      <Palette size={16} className="text-theme-muted group-hover:text-theme-primary transition-colors" />
     </button>
   )
 }

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -35,6 +35,7 @@ export function ThemeSelector({ isOpen, onClose }: ThemeSelectorProps) {
           <button
             onClick={onClose}
             className="p-2 rounded-lg hover:bg-theme-hover text-theme-muted hover:text-theme-text transition-colors"
+            aria-label="Chiudi selettore tema"
           >
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -182,6 +183,7 @@ export function ThemeButton({ onClick }: { onClick: () => void }) {
       onClick={onClick}
       className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-hover border border-theme-border hover:bg-theme-primary-bg transition-colors group"
       title="Cambia tema"
+      aria-label="Cambia tema"
     >
       {theme.gradient ? (
         <div className={`w-5 h-5 rounded bg-gradient-to-br ${theme.gradient}`} />

--- a/src/components/finance/TeamComparison.tsx
+++ b/src/components/finance/TeamComparison.tsx
@@ -6,6 +6,7 @@ import {
 } from 'recharts'
 import { TeamRanking } from './TeamRanking'
 import { SectionHeader } from './KPICard'
+import { LandscapeHint } from '../ui/LandscapeHint'
 import {
   type FinancialsData, type LeagueTotals,
   getTeamBalance, getHealthStatus,
@@ -134,6 +135,7 @@ export function TeamComparison({ data, onTeamClick }: TeamComparisonProps) {
       />
 
       {/* Charts grid */}
+      <LandscapeHint />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {/* Budget vs Ingaggi stacked bar */}
         <div className="bg-surface-300/50 rounded-lg p-3 md:p-4 border border-surface-50/10">

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { X } from 'lucide-react'
 
 interface BottomSheetProps {
   isOpen: boolean
@@ -137,9 +138,7 @@ export function BottomSheet({
                 className="p-2 text-gray-400 hover:text-white rounded-lg hover:bg-surface-100 transition-colors"
                 aria-label="Chiudi"
               >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X size={20} />
               </button>
             </div>
           </div>

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -1,0 +1,521 @@
+import { useState, useMemo, useRef, useEffect, useCallback, type ReactNode } from 'react'
+
+// --- Types ---
+
+export interface ColumnDef<T> {
+  key: string
+  header: string
+  render: (row: T) => ReactNode
+  sortable?: boolean
+  sortFn?: (a: T, b: T) => number
+  className?: string
+  headerClassName?: string
+  /** Width class for desktop/tablet (e.g. 'w-32', 'min-w-[120px]') */
+  width?: string
+}
+
+export interface DataTableProps<T> {
+  data: T[]
+  columns: ColumnDef<T>[]
+  /** Column keys visible on mobile card header (max 3-4) */
+  mobileColumns?: string[]
+  /** Column keys visible on tablet (subset) */
+  tabletColumns?: string[]
+  /** Column keys visible on desktop (all by default) */
+  desktopColumns?: string[]
+  /** Custom mobile card renderer — overrides default card */
+  renderMobileCard?: (row: T, expanded: boolean) => ReactNode
+  /** Sortable columns (global toggle) */
+  sortable?: boolean
+  defaultSort?: { key: string; dir: 'asc' | 'desc' }
+  /** Expandable rows on desktop/tablet */
+  expandable?: boolean
+  renderExpandedRow?: (row: T) => ReactNode
+  /** Items per page — 0 means no pagination */
+  pageSize?: number
+  /** Unique key extractor */
+  getRowKey: (row: T) => string
+  /** Optional className for the wrapper */
+  className?: string
+  /** Optional empty state */
+  emptyState?: ReactNode
+  /** Optional row click */
+  onRowClick?: (row: T) => void
+}
+
+// --- Sorting hook ---
+
+type SortDir = 'asc' | 'desc'
+
+function useSorting<T>(
+  data: T[],
+  columns: ColumnDef<T>[],
+  defaultSort?: { key: string; dir: SortDir }
+) {
+  const [sortKey, setSortKey] = useState<string | null>(defaultSort?.key ?? null)
+  const [sortDir, setSortDir] = useState<SortDir>(defaultSort?.dir ?? 'asc')
+
+  const sorted = useMemo(() => {
+    if (!sortKey) return data
+    const col = columns.find((c) => c.key === sortKey)
+    if (!col?.sortFn) return data
+    const dir = sortDir === 'asc' ? 1 : -1
+    return [...data].sort((a, b) => dir * col.sortFn!(a, b))
+  }, [data, sortKey, sortDir, columns])
+
+  const toggleSort = useCallback(
+    (key: string) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+      } else {
+        setSortKey(key)
+        setSortDir('asc')
+      }
+    },
+    [sortKey]
+  )
+
+  return { sorted, sortKey, sortDir, toggleSort }
+}
+
+// --- Pagination hook ---
+
+function usePagination<T>(data: T[], pageSize: number) {
+  const [page, setPage] = useState(0)
+  const totalPages = pageSize > 0 ? Math.ceil(data.length / pageSize) : 1
+
+  // Reset to page 0 when data length changes
+  useEffect(() => {
+    setPage(0)
+  }, [data.length])
+
+  const paged = useMemo(() => {
+    if (pageSize <= 0) return data
+    return data.slice(page * pageSize, (page + 1) * pageSize)
+  }, [data, page, pageSize])
+
+  return { paged, page, totalPages, setPage }
+}
+
+// --- Scroll shadow hook ---
+
+function useScrollShadow(ref: React.RefObject<HTMLDivElement | null>) {
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(false)
+
+  const update = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    setCanScrollLeft(el.scrollLeft > 4)
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4)
+  }, [ref])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+    }
+  }, [ref, update])
+
+  return { canScrollLeft, canScrollRight }
+}
+
+// --- Sort icon ---
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) {
+    return (
+      <svg className="w-3.5 h-3.5 text-gray-600 ml-1 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+      </svg>
+    )
+  }
+  return (
+    <svg className="w-3.5 h-3.5 text-primary-400 ml-1 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      {dir === 'asc' ? (
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+      ) : (
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+      )}
+    </svg>
+  )
+}
+
+// --- Pagination controls ---
+
+function PaginationControls({
+  page,
+  totalPages,
+  setPage,
+}: {
+  page: number
+  totalPages: number
+  setPage: (p: number) => void
+}) {
+  if (totalPages <= 1) return null
+  return (
+    <div className="flex items-center justify-center gap-2 py-3 border-t border-surface-50/20">
+      <button
+        onClick={() => setPage(Math.max(0, page - 1))}
+        disabled={page === 0}
+        className="px-3 py-1.5 text-xs font-medium rounded-lg bg-surface-300 text-gray-300 hover:bg-surface-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="Pagina precedente"
+      >
+        &laquo; Prec
+      </button>
+      <span className="text-xs text-gray-400">
+        {page + 1} / {totalPages}
+      </span>
+      <button
+        onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
+        disabled={page >= totalPages - 1}
+        className="px-3 py-1.5 text-xs font-medium rounded-lg bg-surface-300 text-gray-300 hover:bg-surface-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="Pagina successiva"
+      >
+        Succ &raquo;
+      </button>
+    </div>
+  )
+}
+
+// --- Main DataTable ---
+
+export function DataTable<T>({
+  data,
+  columns,
+  mobileColumns,
+  tabletColumns,
+  desktopColumns,
+  renderMobileCard,
+  sortable = false,
+  defaultSort,
+  expandable = false,
+  renderExpandedRow,
+  pageSize = 0,
+  getRowKey,
+  className = '',
+  emptyState,
+  onRowClick,
+}: DataTableProps<T>) {
+  const { sorted, sortKey, sortDir, toggleSort } = useSorting(data, columns, defaultSort)
+  const { paged, page, totalPages, setPage } = usePagination(sorted, pageSize)
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const { canScrollLeft, canScrollRight } = useScrollShadow(scrollRef)
+
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
+
+  // Reset expanded on data change
+  useEffect(() => {
+    setExpandedRows(new Set())
+  }, [data.length])
+
+  const toggleExpand = useCallback(
+    (key: string) => {
+      setExpandedRows((prev) => {
+        const next = new Set(prev)
+        if (next.has(key)) {
+          next.delete(key)
+        } else {
+          next.add(key)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  // Column subsets
+  const mobileKeys = useMemo(() => new Set(mobileColumns ?? columns.slice(0, 3).map((c) => c.key)), [mobileColumns, columns])
+  const tabletKeys = useMemo(() => new Set(tabletColumns ?? columns.slice(0, 6).map((c) => c.key)), [tabletColumns, columns])
+  const desktopKeys = useMemo(() => new Set(desktopColumns ?? columns.map((c) => c.key)), [desktopColumns, columns])
+
+  const tabletCols = useMemo(() => columns.filter((c) => tabletKeys.has(c.key)), [columns, tabletKeys])
+  const desktopCols = useMemo(() => columns.filter((c) => desktopKeys.has(c.key)), [columns, desktopKeys])
+  const mobilePrimaryCols = useMemo(() => columns.filter((c) => mobileKeys.has(c.key)), [columns, mobileKeys])
+  const mobileDetailCols = useMemo(
+    () => columns.filter((c) => !mobileKeys.has(c.key)),
+    [columns, mobileKeys]
+  )
+
+  if (data.length === 0 && emptyState) {
+    return <>{emptyState}</>
+  }
+
+  return (
+    <div className={`bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden ${className}`}>
+      {/* ====== DESKTOP TABLE (lg+) ====== */}
+      <div className="hidden lg:block">
+        <table className="w-full text-sm" role="table">
+          <thead>
+            <tr className="bg-surface-300 border-b border-surface-50/20">
+              {expandable && <th className="w-8 px-2" />}
+              {desktopCols.map((col) => {
+                const isSortable = sortable && col.sortable !== false && !!col.sortFn
+                const isActive = sortKey === col.key
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    aria-sort={isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                    className={`px-4 py-2.5 text-left text-xs font-semibold text-gray-400 uppercase tracking-wide ${isSortable ? 'cursor-pointer hover:text-gray-300 select-none' : ''} ${col.headerClassName ?? ''} ${col.width ?? ''}`}
+                    onClick={isSortable ? () => toggleSort(col.key) : undefined}
+                  >
+                    <span className="inline-flex items-center">
+                      {col.header}
+                      {isSortable && <SortIcon active={isActive} dir={sortDir} />}
+                    </span>
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-surface-50/10">
+            {paged.map((row) => {
+              const key = getRowKey(row)
+              const isExp = expandedRows.has(key)
+              return (
+                <DesktopRow
+                  key={key}
+                  row={row}
+                  columns={desktopCols}
+                  expandable={expandable}
+                  isExpanded={isExp}
+                  onToggleExpand={() => toggleExpand(key)}
+                  renderExpandedRow={renderExpandedRow}
+                  onRowClick={onRowClick}
+                />
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ====== TABLET TABLE (md to lg) ====== */}
+      <div className="hidden md:block lg:hidden relative">
+        {/* Left shadow */}
+        {canScrollLeft && (
+          <div className="absolute left-0 top-0 bottom-0 w-6 bg-gradient-to-r from-surface-200 to-transparent z-10 pointer-events-none" />
+        )}
+        {/* Right shadow */}
+        {canScrollRight && (
+          <div className="absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-surface-200 to-transparent z-10 pointer-events-none" />
+        )}
+        <div ref={scrollRef} className="overflow-x-auto">
+          <table className="w-full text-sm min-w-[640px]" role="table">
+            <thead>
+              <tr className="bg-surface-300 border-b border-surface-50/20">
+                {expandable && <th className="w-8 px-2" />}
+                {tabletCols.map((col) => {
+                  const isSortable = sortable && col.sortable !== false && !!col.sortFn
+                  const isActive = sortKey === col.key
+                  return (
+                    <th
+                      key={col.key}
+                      scope="col"
+                      aria-sort={isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                      className={`px-3 py-2.5 text-left text-xs font-semibold text-gray-400 uppercase tracking-wide whitespace-nowrap ${isSortable ? 'cursor-pointer hover:text-gray-300 select-none' : ''} ${col.headerClassName ?? ''} ${col.width ?? ''}`}
+                      onClick={isSortable ? () => toggleSort(col.key) : undefined}
+                    >
+                      <span className="inline-flex items-center">
+                        {col.header}
+                        {isSortable && <SortIcon active={isActive} dir={sortDir} />}
+                      </span>
+                    </th>
+                  )
+                })}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-surface-50/10">
+              {paged.map((row) => {
+                const key = getRowKey(row)
+                const isExp = expandedRows.has(key)
+                return (
+                  <DesktopRow
+                    key={key}
+                    row={row}
+                    columns={tabletCols}
+                    expandable={expandable}
+                    isExpanded={isExp}
+                    onToggleExpand={() => toggleExpand(key)}
+                    renderExpandedRow={renderExpandedRow}
+                    onRowClick={onRowClick}
+                  />
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ====== MOBILE CARD VIEW (<md) ====== */}
+      <div className="md:hidden divide-y divide-surface-50/10">
+        {paged.map((row) => {
+          const key = getRowKey(row)
+          const isExp = expandedRows.has(key)
+
+          if (renderMobileCard) {
+            return (
+              <div
+                key={key}
+                onClick={() => toggleExpand(key)}
+                className="cursor-pointer"
+              >
+                {renderMobileCard(row, isExp)}
+              </div>
+            )
+          }
+
+          return (
+            <MobileCard
+              key={key}
+              row={row}
+              primaryCols={mobilePrimaryCols}
+              detailCols={mobileDetailCols}
+              isExpanded={isExp}
+              onToggle={() => toggleExpand(key)}
+              renderExpandedRow={renderExpandedRow}
+              onRowClick={onRowClick}
+            />
+          )
+        })}
+      </div>
+
+      {/* ====== PAGINATION ====== */}
+      <PaginationControls page={page} totalPages={totalPages} setPage={setPage} />
+    </div>
+  )
+}
+
+// --- Desktop/Tablet row ---
+
+function DesktopRow<T>({
+  row,
+  columns,
+  expandable,
+  isExpanded,
+  onToggleExpand,
+  renderExpandedRow,
+  onRowClick,
+}: {
+  row: T
+  columns: ColumnDef<T>[]
+  expandable: boolean
+  isExpanded: boolean
+  onToggleExpand: () => void
+  renderExpandedRow?: (row: T) => ReactNode
+  onRowClick?: (row: T) => void
+}) {
+  const handleClick = () => {
+    if (onRowClick) onRowClick(row)
+    if (expandable) onToggleExpand()
+  }
+
+  return (
+    <>
+      <tr
+        className={`hover:bg-surface-300/30 transition-colors ${expandable || onRowClick ? 'cursor-pointer' : ''} ${isExpanded ? 'bg-surface-300/50' : ''}`}
+        onClick={handleClick}
+      >
+        {expandable && (
+          <td className="w-8 px-2 text-center">
+            <svg
+              className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </td>
+        )}
+        {columns.map((col) => (
+          <td key={col.key} className={`px-4 py-2.5 ${col.className ?? ''} ${col.width ?? ''}`}>
+            {col.render(row)}
+          </td>
+        ))}
+      </tr>
+      {expandable && isExpanded && renderExpandedRow && (
+        <tr>
+          <td colSpan={columns.length + 1} className="px-4 py-3 bg-surface-300/30 border-t border-surface-50/10">
+            {renderExpandedRow(row)}
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+// --- Mobile card ---
+
+function MobileCard<T>({
+  row,
+  primaryCols,
+  detailCols,
+  isExpanded,
+  onToggle,
+  renderExpandedRow,
+  onRowClick,
+}: {
+  row: T
+  primaryCols: ColumnDef<T>[]
+  detailCols: ColumnDef<T>[]
+  isExpanded: boolean
+  onToggle: () => void
+  renderExpandedRow?: (row: T) => ReactNode
+  onRowClick?: (row: T) => void
+}) {
+  return (
+    <div
+      className={`px-4 py-3 transition-colors ${isExpanded ? 'bg-surface-300/30' : ''}`}
+      onClick={() => {
+        if (onRowClick) onRowClick(row)
+        onToggle()
+      }}
+    >
+      {/* Primary info row */}
+      <div className="flex items-center justify-between cursor-pointer">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          {primaryCols.map((col) => (
+            <div key={col.key} className={`${col.className ?? ''}`}>
+              {col.render(row)}
+            </div>
+          ))}
+        </div>
+        <svg
+          className={`w-4 h-4 text-gray-500 flex-shrink-0 ml-2 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+
+      {/* Expanded details */}
+      {isExpanded && (
+        <div className="mt-3 pt-3 border-t border-surface-50/10 space-y-2">
+          {detailCols.map((col) => (
+            <div key={col.key} className="flex justify-between items-center text-sm">
+              <span className="text-gray-500 text-xs">{col.header}</span>
+              <span className={col.className ?? ''}>{col.render(row)}</span>
+            </div>
+          ))}
+          {renderExpandedRow && (
+            <div className="mt-2 pt-2 border-t border-surface-50/10">
+              {renderExpandedRow(row)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DataTable

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,20 @@
+interface EmptyStateProps {
+  icon?: string
+  title: string
+  description?: string
+  action?: React.ReactNode
+  compact?: boolean
+}
+
+export function EmptyState({ icon = '📭', title, description, action, compact = false }: EmptyStateProps) {
+  return (
+    <div className={`bg-surface-200 rounded-xl border border-surface-50/20 text-center ${compact ? 'p-6' : 'p-12'}`}>
+      <div className={`${compact ? 'text-3xl' : 'text-4xl'} mb-3 opacity-50`}>{icon}</div>
+      <p className={`${compact ? 'text-sm' : 'text-base'} text-gray-400 font-medium`}>{title}</p>
+      {description && (
+        <p className="text-xs text-gray-500 mt-1 max-w-md mx-auto">{description}</p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}

--- a/src/components/ui/LandscapeHint.tsx
+++ b/src/components/ui/LandscapeHint.tsx
@@ -1,0 +1,10 @@
+export function LandscapeHint() {
+  return (
+    <div className="md:hidden flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-300/50 border border-surface-50/10 text-xs text-gray-400 mb-3">
+      <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+      <span>Ruota il telefono per una visualizzazione migliore dei grafici</span>
+    </div>
+  )
+}

--- a/src/components/ui/LandscapeHint.tsx
+++ b/src/components/ui/LandscapeHint.tsx
@@ -1,9 +1,9 @@
+import { RotateCcw } from 'lucide-react'
+
 export function LandscapeHint() {
   return (
     <div className="md:hidden flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-300/50 border border-surface-50/10 text-xs text-gray-400 mb-3">
-      <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-      </svg>
+      <RotateCcw size={16} className="flex-shrink-0" />
       <span>Ruota il telefono per una visualizzazione migliore dei grafici</span>
     </div>
   )

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -6,6 +6,7 @@ import {
   type HTMLAttributes,
 } from 'react'
 import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
 
 type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full'
 
@@ -135,20 +136,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(
               "
               aria-label="Chiudi modale"
             >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X size={20} aria-hidden="true" />
             </button>
           )}
 

--- a/src/components/ui/ScrollToTop.tsx
+++ b/src/components/ui/ScrollToTop.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { ChevronUp } from 'lucide-react'
 
 export function ScrollToTop() {
   const [visible, setVisible] = useState(false)
@@ -17,9 +18,7 @@ export function ScrollToTop() {
       aria-label="Torna in cima"
       className="fixed bottom-6 right-6 z-50 w-11 h-11 rounded-full bg-primary-500 text-white shadow-lg hover:bg-primary-600 transition-all duration-200 flex items-center justify-center md:hidden"
     >
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-      </svg>
+      <ChevronUp size={20} />
     </button>
   )
 }

--- a/src/components/ui/ScrollToTop.tsx
+++ b/src/components/ui/ScrollToTop.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react'
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  if (!visible) return null
+
+  return (
+    <button
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      aria-label="Torna in cima"
+      className="fixed bottom-6 right-6 z-50 w-11 h-11 rounded-full bg-primary-500 text-white shadow-lg hover:bg-primary-600 transition-all duration-200 flex items-center justify-center md:hidden"
+    >
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+      </svg>
+    </button>
+  )
+}

--- a/src/components/ui/StickyActionBar.tsx
+++ b/src/components/ui/StickyActionBar.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface StickyActionBarProps {
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Sticky action bar fixed at the bottom of the screen.
+ * On mobile (<md), sits above the BottomNavBar (bottom-14).
+ * On desktop (md+), sits at bottom-0.
+ * Includes safe-area-inset-bottom for notched devices.
+ */
+export function StickyActionBar({ children, className = '' }: StickyActionBarProps) {
+  return (
+    <div
+      className={`fixed left-0 right-0 bottom-14 md:bottom-0 z-40 bg-gradient-to-r from-surface-200 via-surface-200 to-surface-200 border-t-2 border-primary-500/50 shadow-lg shadow-black/30 ${className}`}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default StickyActionBar

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,59 @@
+import { useState, useRef, useEffect, type ReactNode } from 'react'
+
+interface TooltipProps {
+  content: ReactNode
+  children: ReactNode
+  className?: string
+  /** Position relative to children */
+  position?: 'top' | 'bottom'
+}
+
+/**
+ * Tooltip component:
+ * - Desktop: shows on hover
+ * - Mobile: shows on tap (toggle)
+ */
+export function Tooltip({ content, children, className = '', position = 'top' }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Close on outside click (for mobile tap-to-toggle)
+  useEffect(() => {
+    if (!visible) return
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setVisible(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [visible])
+
+  const positionClasses = position === 'top'
+    ? 'bottom-full mb-2 left-1/2 -translate-x-1/2'
+    : 'top-full mt-2 left-1/2 -translate-x-1/2'
+
+  return (
+    <div
+      ref={ref}
+      className={`relative inline-flex ${className}`}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onClick={(e) => {
+        e.stopPropagation()
+        setVisible((v) => !v)
+      }}
+    >
+      {children}
+      {visible && (
+        <div className={`absolute z-50 ${positionClasses} pointer-events-none`}>
+          <div className="bg-surface-100 border border-surface-50/30 rounded-lg px-3 py-2 text-xs text-gray-300 shadow-xl shadow-black/40 whitespace-normal max-w-[220px] text-center leading-relaxed">
+            {content}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Tooltip

--- a/src/pages/AllPlayers.tsx
+++ b/src/pages/AllPlayers.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Navigation } from '../components/Navigation'
 import { playerApi, leagueApi } from '../services/api'
 import { Input } from '../components/ui/Input'
+import { EmptyState } from '../components/ui/EmptyState'
 import { POSITION_GRADIENTS, POSITION_FILTER_COLORS } from '../components/ui/PositionBadge'
 import { PlayerStatsModal, type PlayerInfo, type PlayerStats } from '../components/PlayerStatsModal'
 import { getPlayerPhotoUrl } from '../utils/player-images'
@@ -159,9 +160,9 @@ export function AllPlayers({ leagueId, onNavigate, initialTeamFilter }: AllPlaye
     <div className="min-h-screen bg-dark-100">
       <Navigation currentPage="allPlayers" leagueId={leagueId} isLeagueAdmin={isLeagueAdmin} onNavigate={onNavigate} />
 
-      <div className="max-w-[1600px] mx-auto px-4 py-6">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-white">Tutti i Giocatori</h1>
+      <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">
+        <div className="mb-4 md:mb-6">
+          <h1 className="text-xl md:text-2xl font-bold text-white">Tutti i Giocatori</h1>
           <p className="text-gray-400">{leagueName}</p>
         </div>
 
@@ -229,8 +230,17 @@ export function AllPlayers({ leagueId, onNavigate, initialTeamFilter }: AllPlaye
 
         {/* Results */}
         {isLoading ? (
-          <div className="flex items-center justify-center h-40">
-            <div className="animate-spin h-8 w-8 border-4 border-primary-500 border-t-transparent rounded-full" />
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 p-3 bg-surface-200/50 rounded-lg animate-pulse">
+                <div className="w-10 h-10 rounded-full bg-surface-100" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-32 bg-surface-100 rounded" />
+                  <div className="h-3 w-20 bg-surface-100 rounded" />
+                </div>
+                <div className="h-6 w-16 bg-surface-100 rounded" />
+              </div>
+            ))}
           </div>
         ) : (
           <div className="bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden">
@@ -239,9 +249,7 @@ export function AllPlayers({ leagueId, onNavigate, initialTeamFilter }: AllPlaye
             </div>
 
             {filteredPlayers.length === 0 ? (
-              <div className="p-8 text-center text-gray-400">
-                Nessun giocatore trovato
-              </div>
+              <EmptyState icon="🔍" title="Nessun giocatore trovato" description="Prova a cambiare i filtri di ricerca." compact />
             ) : (
               <div className="divide-y divide-surface-50/10">
                 {filteredPlayers.slice(0, 100).map(player => (

--- a/src/pages/Contracts.tsx
+++ b/src/pages/Contracts.tsx
@@ -929,6 +929,8 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
                 placeholder="Cerca..."
+                inputMode="search"
+                enterKeyHint="search"
                 className="w-32 px-2 py-1 bg-surface-300 border border-surface-50/30 rounded text-white text-sm"
               />
               <select
@@ -942,6 +944,27 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                 <option value="C">C</option>
                 <option value="A">A</option>
               </select>
+            </div>
+
+            {/* Duration color legend */}
+            <div className="flex items-center gap-3 text-xs text-gray-400 flex-wrap">
+              <span>Durata:</span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded bg-gradient-to-r from-red-500 to-red-600" />
+                1 sem
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded bg-gradient-to-r from-yellow-500 to-yellow-600" />
+                2 sem
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded bg-gradient-to-r from-green-500 to-green-600" />
+                3 sem
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded bg-gradient-to-r from-blue-500 to-blue-600" />
+                4+ sem
+              </span>
             </div>
 
             {/* Azioni - Desktop only */}
@@ -1173,13 +1196,13 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="bg-warning-500/10 text-xs text-gray-400 uppercase">
-                      <th className="text-left p-2">Giocatore</th>
-                      <th className="text-center p-2">Acquisto</th>
-                      <th className="text-center p-2">Min Ing.</th>
-                      <th className="text-center p-2 border-l border-surface-50/20">Ingaggio</th>
-                      <th className="text-center p-2">Durata</th>
-                      <th className="text-center p-2">Clausola</th>
-                      <th className="text-center p-2">Nuova Rubata</th>
+                      <th scope="col" className="text-left p-2">Giocatore</th>
+                      <th scope="col" className="text-center p-2">Acquisto</th>
+                      <th scope="col" className="text-center p-2">Min Ing.</th>
+                      <th scope="col" className="text-center p-2 border-l border-surface-50/20">Ingaggio</th>
+                      <th scope="col" className="text-center p-2">Durata</th>
+                      <th scope="col" className="text-center p-2">Clausola</th>
+                      <th scope="col" className="text-center p-2">Nuova Rubata</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2050,11 +2073,11 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="bg-danger-500/10 text-xs text-danger-400 uppercase">
-                    <th className="text-left p-2">Giocatore</th>
-                    <th className="text-center p-2">Ing.</th>
-                    <th className="text-center p-2">Dur.</th>
-                    <th className="text-center p-2">Costo Taglio</th>
-                    <th className="text-center p-2">Note</th>
+                    <th scope="col" className="text-left p-2">Giocatore</th>
+                    <th scope="col" className="text-center p-2">Ing.</th>
+                    <th scope="col" className="text-center p-2">Dur.</th>
+                    <th scope="col" className="text-center p-2">Costo Taglio</th>
+                    <th scope="col" className="text-center p-2">Note</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/pages/Contracts.tsx
+++ b/src/pages/Contracts.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { contractApi, leagueApi } from '../services/api'
 import { Button } from '../components/ui/Button'
+import { Tooltip } from '../components/ui/Tooltip'
+import { StickyActionBar } from '../components/ui/StickyActionBar'
 import { Navigation } from '../components/Navigation'
 import { getTeamLogo } from '../utils/teamLogos'
 import { POSITION_COLORS } from '../components/ui/PositionBadge'
@@ -1504,28 +1506,30 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                     </button>
                     {contract.canSpalmare && !isMarkedForRelease && (
                       newSalary < contract.salary ? (
-                        <span
-                          className="px-1.5 py-0.5 bg-secondary-500/20 border border-secondary-500/40 rounded text-secondary-400 text-[10px] font-bold"
-                          title={`Spalma applicato: ${newSalary}M × ${newDuration}s = ${newSalary * newDuration} ≥ ${contract.initialSalary}`}
-                        >
-                          SPALMATO
-                        </span>
+                        <Tooltip content={`Spalma applicato: ingaggio ridotto a ${newSalary}M allungando la durata a ${newDuration}s. Il costo totale (${newSalary * newDuration}M) resta ≥ ${contract.initialSalary}M.`}>
+                          <span className="px-1.5 py-0.5 bg-secondary-500/20 border border-secondary-500/40 rounded text-secondary-400 text-[10px] font-bold cursor-help">
+                            SPALMATO
+                          </span>
+                        </Tooltip>
                       ) : (
-                        <span
-                          className="px-1.5 py-0.5 bg-warning-500/20 border border-warning-500/40 rounded text-warning-400 text-[10px] font-bold"
-                          title={`Spalma disponibile: Nuovo Ing. × Nuova Dur. ≥ ${contract.initialSalary}M`}
-                        >
-                          SPALMABILE
-                        </span>
+                        <Tooltip content={`Puoi ridurre l'ingaggio allungando la durata. Regola: Nuovo Ing. × Nuova Dur. ≥ ${contract.initialSalary}M.`}>
+                          <span className="px-1.5 py-0.5 bg-warning-500/20 border border-warning-500/40 rounded text-warning-400 text-[10px] font-bold cursor-help">
+                            SPALMABILE
+                          </span>
+                        </Tooltip>
                       )
                     )}
                     {isMarkedForRelease && (
-                      <span className="text-danger-400 text-[10px] font-bold">DA TAGLIARE</span>
+                      <Tooltip content="Questo giocatore verrà tagliato al consolidamento. Il costo del taglio è (Ingaggio × Durata) / 2.">
+                        <span className="text-danger-400 text-[10px] font-bold cursor-help">DA TAGLIARE</span>
+                      </Tooltip>
                     )}
                     {isKeptExited && (
-                      <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-500/40 rounded text-green-400 text-[10px] font-bold">
-                        MANTENUTO
-                      </span>
+                      <Tooltip content="Contratto scaduto ma hai scelto di mantenere il giocatore. Rinnova ingaggio e durata.">
+                        <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-500/40 rounded text-green-400 text-[10px] font-bold cursor-help">
+                          MANTENUTO
+                        </span>
+                      </Tooltip>
                     )}
                   </div>
 
@@ -1549,9 +1553,11 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
 
                   {/* Trade info badge */}
                   {contract.roster.acquisitionType === 'TRADE' && (
-                    <div className="bg-purple-500/20 border border-purple-500/50 rounded px-2 py-1 mb-2 text-center">
-                      <span className="text-purple-400 text-xs font-bold">↔️ SCAMBIO</span>
-                    </div>
+                    <Tooltip content="Giocatore acquisito tramite scambio. Il contratto originale viene mantenuto." position="bottom">
+                      <div className="bg-purple-500/20 border border-purple-500/50 rounded px-2 py-1 mb-2 text-center cursor-help">
+                        <span className="text-purple-400 text-xs font-bold">↔️ SCAMBIO</span>
+                      </div>
+                    </Tooltip>
                   )}
 
                   {/* Current contract info */}
@@ -1855,32 +1861,35 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                             </button>
                             {contract.canSpalmare && !isMarkedForRelease && (
                               newSalary < contract.salary ? (
-                                <span
-                                  className="px-1.5 py-0.5 bg-secondary-500/20 border border-secondary-500/40 rounded text-secondary-400 text-[10px] font-bold cursor-help"
-                                  title={`Spalma applicato: ${newSalary}M × ${newDuration}s = ${newSalary * newDuration} ≥ ${contract.initialSalary}`}
-                                >
-                                  SPALMATO
-                                </span>
+                                <Tooltip content={`Spalma applicato: ingaggio ridotto a ${newSalary}M allungando la durata a ${newDuration}s. Costo totale (${newSalary * newDuration}M) ≥ ${contract.initialSalary}M.`}>
+                                  <span className="px-1.5 py-0.5 bg-secondary-500/20 border border-secondary-500/40 rounded text-secondary-400 text-[10px] font-bold cursor-help">
+                                    SPALMATO
+                                  </span>
+                                </Tooltip>
                               ) : (
-                                <span
-                                  className="px-1.5 py-0.5 bg-warning-500/20 border border-warning-500/40 rounded text-warning-400 text-[10px] font-bold cursor-help"
-                                  title={`Spalma disponibile: Nuovo Ing. × Nuova Dur. ≥ ${contract.initialSalary}M`}
-                                >
-                                  SPALMABILE
-                                </span>
+                                <Tooltip content={`Puoi ridurre l'ingaggio allungando la durata. Regola: Nuovo Ing. × Nuova Dur. ≥ ${contract.initialSalary}M.`}>
+                                  <span className="px-1.5 py-0.5 bg-warning-500/20 border border-warning-500/40 rounded text-warning-400 text-[10px] font-bold cursor-help">
+                                    SPALMABILE
+                                  </span>
+                                </Tooltip>
                               )
                             )}
                             {contract.roster.acquisitionType === 'TRADE' && (
-                              <span className="text-purple-400 text-[10px] font-bold px-1 py-0.5 bg-purple-500/20 rounded">↔️ SCAMBIO</span>
+                              <Tooltip content="Acquisito tramite scambio. Il contratto originale viene mantenuto.">
+                                <span className="text-purple-400 text-[10px] font-bold px-1 py-0.5 bg-purple-500/20 rounded cursor-help">↔️ SCAMBIO</span>
+                              </Tooltip>
                             )}
                             {isMarkedForRelease && (
-                              <span className="text-danger-400 text-xs font-medium">DA TAGLIARE</span>
+                              <Tooltip content="Verrà tagliato al consolidamento. Costo: (Ingaggio × Durata) / 2.">
+                                <span className="text-danger-400 text-xs font-medium cursor-help">DA TAGLIARE</span>
+                              </Tooltip>
                             )}
                             {isKeptExited && (
-                              <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-500/40 rounded text-green-400 text-[10px] font-bold cursor-help"
-                                title="Giocatore uscito mantenuto in rosa">
-                                MANTENUTO
-                              </span>
+                              <Tooltip content="Contratto scaduto ma mantenuto in rosa. Rinnova ingaggio e durata.">
+                                <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-500/40 rounded text-green-400 text-[10px] font-bold cursor-help">
+                                  MANTENUTO
+                                </span>
+                              </Tooltip>
                             )}
                           </div>
                         </td>
@@ -2280,7 +2289,7 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
       </main>
 
       {/* Sticky Budget Bar - Prominente */}
-      <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-r from-surface-200 via-surface-200 to-surface-200 border-t-2 border-primary-500/50 z-40 shadow-lg shadow-black/30">
+      <StickyActionBar>
         <div className="max-w-[1600px] mx-auto px-4 py-3">
           {/* Mobile: layout con pulsanti azione fissi */}
           <div className="md:hidden">
@@ -2407,7 +2416,7 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
             </div>
           </div>
         </div>
-      </div>
+      </StickyActionBar>
 
       {/* Player Stats Modal */}
       <PlayerStatsModal

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -119,9 +119,14 @@ export function Dashboard({ onNavigate }: DashboardProps) {
         </div>
 
         {isLoading ? (
-          <div className="text-center py-20">
-            <div className="w-16 h-16 border-4 border-primary-500/30 border-t-primary-500 rounded-full animate-spin mx-auto"></div>
-            <p className="mt-6 text-lg text-gray-400">Caricamento leghe...</p>
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="bg-surface-200 rounded-xl p-4 space-y-3 border border-surface-50/20 animate-pulse">
+                <div className="h-4 w-3/4 bg-surface-100 rounded" />
+                <div className="h-4 w-1/2 bg-surface-100 rounded" />
+                <div className="h-8 w-full bg-surface-100 rounded" />
+              </div>
+            ))}
           </div>
         ) : leagues.length === 0 ? (
           <div className="bg-surface-200 rounded-2xl border border-surface-50/20 p-16 text-center">

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -88,6 +88,7 @@ export function ForgotPassword() {
             <Input
               id="email"
               type="email"
+              inputMode="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="La tua email"

--- a/src/pages/LeagueDetail.tsx
+++ b/src/pages/LeagueDetail.tsx
@@ -162,10 +162,23 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-dark-300 flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-16 h-16 border-4 border-primary-500/30 border-t-primary-500 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-lg text-gray-400">Caricamento lega...</p>
+      <div className="min-h-screen bg-dark-300">
+        <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-6 space-y-6 animate-pulse">
+          <div className="h-8 w-48 bg-surface-100 rounded" />
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="bg-surface-200 rounded-xl p-4 space-y-3 border border-surface-50/20">
+                <div className="h-4 w-3/4 bg-surface-100 rounded" />
+                <div className="h-4 w-1/2 bg-surface-100 rounded" />
+                <div className="h-8 w-full bg-surface-100 rounded" />
+              </div>
+            ))}
+          </div>
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-16 bg-surface-200 rounded-lg border border-surface-50/20" />
+            ))}
+          </div>
         </div>
       </div>
     )
@@ -194,28 +207,28 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
 
       {/* League Header */}
       <div className="bg-gradient-to-r from-dark-200 via-surface-200 to-dark-200 border-b border-surface-50/20">
-        <div className="max-w-[1600px] mx-auto px-6 py-6">
-          <div className="flex justify-between items-end">
-            <div className="flex items-center gap-5">
-              <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center shadow-glow">
-                <span className="text-3xl">🏟️</span>
+        <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-4 sm:py-6">
+          <div className="flex justify-between items-end gap-3">
+            <div className="flex items-center gap-3 sm:gap-5 min-w-0">
+              <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-xl bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center shadow-glow flex-shrink-0">
+                <span className="text-2xl sm:text-3xl">🏟️</span>
               </div>
-              <div>
-                <h1 className="text-3xl font-bold text-white">{league.name}</h1>
-                <p className="text-gray-400 mt-1">
+              <div className="min-w-0">
+                <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-white truncate">{league.name}</h1>
+                <p className="text-gray-400 mt-1 text-sm">
                   {league.status === 'DRAFT' ? '📋 In preparazione' : league.status === 'ACTIVE' ? '🔥 Primo Mercato' : league.status}
                 </p>
               </div>
             </div>
-            <div className="text-right bg-surface-200 rounded-xl px-6 py-4 border border-surface-50/20">
-              <p className="text-sm text-gray-400 uppercase tracking-wide">Il tuo Budget</p>
-              <p className="text-4xl font-bold text-accent-400">{userMembership?.currentBudget || 0}</p>
+            <div className="text-right bg-surface-200 rounded-xl px-3 py-2 sm:px-6 sm:py-4 border border-surface-50/20 flex-shrink-0">
+              <p className="text-xs sm:text-sm text-gray-400 uppercase tracking-wide">Il tuo Budget</p>
+              <p className="text-2xl sm:text-4xl font-bold text-accent-400">{userMembership?.currentBudget || 0}</p>
             </div>
           </div>
         </div>
       </div>
 
-      <main className="max-w-[1600px] mx-auto px-6 py-8">
+      <main className="max-w-[1600px] mx-auto px-4 sm:px-6 py-4 sm:py-8">
         {error && (
           <div className="bg-danger-500/20 border border-danger-500/50 text-danger-400 p-4 rounded-xl mb-6 text-base">
             {error}
@@ -311,26 +324,40 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
           const showButton = !(config.adminOnly && !isAdmin)
 
           return (
-            <div className={`bg-gradient-to-r ${colors.bg} border-2 ${colors.border} rounded-2xl p-6 mb-8 flex items-center justify-between`}>
-              <div className="flex items-center gap-4">
-                <div className={`w-14 h-14 rounded-full ${colors.iconBg} flex items-center justify-center animate-pulse`}>
-                  <span className="text-3xl">{config.icon}</span>
+            <button
+              onClick={getNavTarget()}
+              className={`bg-gradient-to-r ${colors.bg} border-2 ${colors.border} rounded-2xl p-4 sm:p-6 mb-8 flex items-center justify-between w-full text-left cursor-pointer hover:translate-x-1 hover:border-primary-500/50 transition-all duration-200 group`}
+              role="link"
+            >
+              <div className="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
+                <div className={`w-12 h-12 sm:w-14 sm:h-14 rounded-full ${colors.iconBg} flex items-center justify-center animate-pulse flex-shrink-0`}>
+                  <span className="text-2xl sm:text-3xl">{config.icon}</span>
                 </div>
-                <div>
-                  <h2 className={`text-xl font-bold ${colors.text}`}>{config.title}</h2>
-                  <p className="text-gray-300">{config.description}</p>
+                <div className="min-w-0">
+                  <h2 className={`text-lg sm:text-xl font-bold ${colors.text}`}>{config.title}</h2>
+                  <p className="text-gray-300 text-sm sm:text-base">{config.description}</p>
+                  <span className={`text-xs ${colors.text} font-medium mt-1 inline-block md:hidden`}>
+                    Vai alla fase &rarr;
+                  </span>
                 </div>
               </div>
-              {showButton && (
-                <Button
-                  size="lg"
-                  variant={config.color === 'secondary' ? 'secondary' : 'primary'}
-                  onClick={getNavTarget()}
-                >
-                  {config.buttonText}
-                </Button>
-              )}
-            </div>
+              <div className="flex items-center gap-3 flex-shrink-0 ml-3">
+                {showButton && (
+                  <span className="hidden md:inline-block">
+                    <Button
+                      size="lg"
+                      variant={config.color === 'secondary' ? 'secondary' : 'primary'}
+                      tabIndex={-1}
+                    >
+                      {config.buttonText}
+                    </Button>
+                  </span>
+                )}
+                <svg className={`w-5 h-5 ${colors.text} group-hover:translate-x-1 transition-transform duration-200`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </div>
+            </button>
           )
         })()}
 
@@ -506,7 +533,8 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
                         default: break
                       }
                     }}
-                    className="w-full p-4 bg-primary-500/20 border border-primary-500/40 rounded-xl text-left hover:bg-primary-500/30 transition-colors group"
+                    className="w-full p-4 bg-primary-500/20 border border-primary-500/40 rounded-xl text-left hover:bg-primary-500/30 hover:translate-x-0.5 hover:border-primary-500/60 transition-all duration-200 group cursor-pointer"
+                    role="link"
                   >
                     <div className="flex justify-between items-start">
                       <div>
@@ -525,8 +553,13 @@ export function LeagueDetail({ leagueId, onNavigate }: LeagueDetailProps) {
                             })}
                           </p>
                         )}
+                        <span className="text-xs text-primary-400 font-medium mt-1 inline-block md:hidden">
+                          Vai alla fase &rarr;
+                        </span>
                       </div>
-                      <span className="text-primary-500 group-hover:text-primary-400 transition-colors text-xl">→</span>
+                      <svg className="w-5 h-5 text-primary-500 group-hover:text-primary-400 group-hover:translate-x-1 transition-all duration-200 flex-shrink-0 mt-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
                     </div>
                   </button>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -86,6 +86,8 @@ export function Login({ onNavigate }: LoginProps) {
             <Input
               label="Email o Username"
               type="text"
+              inputMode="email"
+              autoComplete="email"
               value={emailOrUsername}
               onChange={e => setEmailOrUsername(e.target.value)}
               placeholder="mario@email.com"

--- a/src/pages/Movements.tsx
+++ b/src/pages/Movements.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { movementApi, leagueApi } from '../services/api'
 import { Button } from '../components/ui/Button'
+import { EmptyState } from '../components/ui/EmptyState'
 import { Navigation } from '../components/Navigation'
 import { getTeamLogo } from '../utils/teamLogos'
 
@@ -189,10 +190,19 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-dark-300 flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-primary-500/30 border-t-primary-500 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-400">Caricamento storico...</p>
+      <div className="min-h-screen bg-dark-300">
+        <Navigation currentPage="movements" leagueId={leagueId} isLeagueAdmin={isLeagueAdmin} onNavigate={onNavigate} />
+        <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 p-3 bg-surface-200 rounded-lg animate-pulse">
+              <div className="w-8 h-8 rounded bg-surface-100" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-40 bg-surface-100 rounded" />
+                <div className="h-3 w-24 bg-surface-100 rounded" />
+              </div>
+              <div className="h-4 w-16 bg-surface-100 rounded" />
+            </div>
+          ))}
         </div>
       </div>
     )
@@ -204,7 +214,7 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
 
       {/* Header compatto */}
       <div className="bg-surface-200 border-b border-surface-50/20">
-        <div className="max-w-[1600px] mx-auto px-6 py-4">
+        <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
@@ -246,7 +256,7 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
         </div>
       </div>
 
-      <main className="max-w-[1600px] mx-auto px-6 py-4">
+      <main className="max-w-[1600px] mx-auto px-4 md:px-6 py-4">
         {error && (
           <div className="bg-danger-500/20 border border-danger-500/50 text-danger-400 p-3 rounded-lg mb-4 text-sm">
             {error}
@@ -254,22 +264,19 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
         )}
 
         {movements.length === 0 ? (
-          <div className="bg-surface-200 rounded-xl border border-surface-50/20 p-12 text-center">
-            <div className="text-4xl mb-3 opacity-50">📭</div>
-            <p className="text-gray-400">Nessun movimento registrato</p>
-          </div>
+          <EmptyState icon="📭" title="Nessun movimento registrato" description="I movimenti appariranno qui dopo aste, scambi e altre operazioni." />
         ) : (
           <div className="bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden">
             {/* Table Header */}
-            <div className="grid grid-cols-12 gap-2 px-4 py-2 bg-surface-300 border-b border-surface-50/20 text-xs font-semibold text-gray-400 uppercase tracking-wide">
-              <div className="col-span-1">Tipo</div>
-              <div className="col-span-1">Stag.</div>
-              <div className="col-span-1">Sem.</div>
-              <div className="col-span-3">Giocatore</div>
-              <div className="col-span-2">Da → A</div>
-              <div className="col-span-1 text-right">Prezzo</div>
-              <div className="col-span-2">Contratto</div>
-              <div className="col-span-1 text-right">Data</div>
+            <div role="row" className="grid grid-cols-12 gap-2 px-4 py-2 bg-surface-300 border-b border-surface-50/20 text-xs font-semibold text-gray-400 uppercase tracking-wide">
+              <div role="columnheader" className="col-span-1">Tipo</div>
+              <div role="columnheader" className="col-span-1">Stag.</div>
+              <div role="columnheader" className="col-span-1">Sem.</div>
+              <div role="columnheader" className="col-span-3">Giocatore</div>
+              <div role="columnheader" className="col-span-2">Da &rarr; A</div>
+              <div role="columnheader" className="col-span-1 text-right">Prezzo</div>
+              <div role="columnheader" className="col-span-2">Contratto</div>
+              <div role="columnheader" className="col-span-1 text-right">Data</div>
             </div>
 
             {/* Table Rows */}

--- a/src/pages/Movements.tsx
+++ b/src/pages/Movements.tsx
@@ -3,7 +3,9 @@ import { movementApi, leagueApi } from '../services/api'
 import { Button } from '../components/ui/Button'
 import { EmptyState } from '../components/ui/EmptyState'
 import { Navigation } from '../components/Navigation'
+import { BottomSheet } from '../components/ui/BottomSheet'
 import { getTeamLogo } from '../utils/teamLogos'
+import { ChevronDown, SlidersHorizontal } from 'lucide-react'
 
 interface MovementsProps {
   leagueId: string
@@ -100,6 +102,7 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
   const [error, setError] = useState('')
   const [filterType, setFilterType] = useState<string>('')
   const [filterSemester, setFilterSemester] = useState<string>('')
+  const [filtersOpen, setFiltersOpen] = useState(false)
   const [isLeagueAdmin, setIsLeagueAdmin] = useState(false)
 
   // Prophecy
@@ -215,23 +218,37 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
       {/* Header compatto */}
       <div className="bg-surface-200 border-b border-surface-50/20">
         <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center flex-shrink-0">
                 <span className="text-xl">📜</span>
               </div>
               <div>
-                <h1 className="text-xl font-bold text-white">Storico Movimenti</h1>
-                <p className="text-xs text-gray-500">Stagione {formatSeason(2025)}</p>
+                <h1 className="text-lg sm:text-xl font-bold text-white">Storico Movimenti</h1>
+                <p className="text-xs text-gray-500">Stagione {formatSeason(2025)} · {movements.length} mov.</p>
               </div>
             </div>
 
-            {/* Filtri inline */}
-            <div className="flex items-center gap-3">
+            {/* Filtri — Mobile: button, Desktop: inline */}
+            <div className="flex items-center gap-2">
+              {/* Mobile: Filtri button */}
+              <button
+                onClick={() => setFiltersOpen(true)}
+                className="md:hidden flex items-center gap-1.5 px-3 py-1.5 bg-surface-300 border border-surface-50/30 rounded-lg text-xs text-gray-300 hover:text-white transition-colors"
+              >
+                <SlidersHorizontal size={14} />
+                Filtri{(filterType || filterSemester) && (
+                  <span className="ml-0.5 px-1.5 py-0.5 text-[10px] font-bold bg-primary-500/30 text-primary-400 rounded-full">
+                    {[filterType, filterSemester].filter(Boolean).length}
+                  </span>
+                )}
+              </button>
+
+              {/* Desktop: inline selects */}
               <select
                 value={filterType}
                 onChange={(e) => setFilterType(e.target.value)}
-                className="bg-surface-300 border border-surface-50/30 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none"
+                className="hidden md:block bg-surface-300 border border-surface-50/30 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none"
               >
                 <option value="">Tutti i tipi</option>
                 <option value="FIRST_MARKET">Primo Mercato</option>
@@ -244,17 +261,58 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
               <select
                 value={filterSemester}
                 onChange={(e) => setFilterSemester(e.target.value)}
-                className="bg-surface-300 border border-surface-50/30 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none"
+                className="hidden md:block bg-surface-300 border border-surface-50/30 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none"
               >
-                <option value="">Tutti i semestri</option>
-                <option value="1">1° Semestre</option>
-                <option value="2">2° Semestre</option>
+                <option value="">Tutti</option>
+                <option value="1">1° Sem</option>
+                <option value="2">2° Sem</option>
               </select>
-              <span className="text-xs text-gray-500">{movements.length} mov.</span>
             </div>
           </div>
         </div>
       </div>
+
+      {/* Mobile Filters BottomSheet */}
+      <BottomSheet isOpen={filtersOpen} onClose={() => setFiltersOpen(false)} title="Filtri Movimenti">
+        <div className="p-4 space-y-5">
+          <div>
+            <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Tipo Movimento</label>
+            <select
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              className="w-full px-3 py-2.5 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              <option value="">Tutti i tipi</option>
+              <option value="FIRST_MARKET">Primo Mercato</option>
+              <option value="TRADE">Scambi</option>
+              <option value="RUBATA">Rubate</option>
+              <option value="SVINCOLATI">Svincolati</option>
+              <option value="RELEASE">Tagli</option>
+              <option value="CONTRACT_RENEW">Rinnovi</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Semestre</label>
+            <select
+              value={filterSemester}
+              onChange={(e) => setFilterSemester(e.target.value)}
+              className="w-full px-3 py-2.5 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              <option value="">Tutti i semestri</option>
+              <option value="1">1° Semestre</option>
+              <option value="2">2° Semestre</option>
+            </select>
+          </div>
+
+          <button
+            onClick={() => setFiltersOpen(false)}
+            className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors"
+          >
+            Applica Filtri
+          </button>
+        </div>
+      </BottomSheet>
 
       <main className="max-w-[1600px] mx-auto px-4 md:px-6 py-4">
         {error && (
@@ -266,21 +324,9 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
         {movements.length === 0 ? (
           <EmptyState icon="📭" title="Nessun movimento registrato" description="I movimenti appariranno qui dopo aste, scambi e altre operazioni." />
         ) : (
-          <div className="bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden">
-            {/* Table Header */}
-            <div role="row" className="grid grid-cols-12 gap-2 px-4 py-2 bg-surface-300 border-b border-surface-50/20 text-xs font-semibold text-gray-400 uppercase tracking-wide">
-              <div role="columnheader" className="col-span-1">Tipo</div>
-              <div role="columnheader" className="col-span-1">Stag.</div>
-              <div role="columnheader" className="col-span-1">Sem.</div>
-              <div role="columnheader" className="col-span-3">Giocatore</div>
-              <div role="columnheader" className="col-span-2">Da &rarr; A</div>
-              <div role="columnheader" className="col-span-1 text-right">Prezzo</div>
-              <div role="columnheader" className="col-span-2">Contratto</div>
-              <div role="columnheader" className="col-span-1 text-right">Data</div>
-            </div>
-
-            {/* Table Rows */}
-            <div className="divide-y divide-surface-50/10">
+          <>
+            {/* ====== MOBILE CARD VIEW (<md) ====== */}
+            <div className="md:hidden space-y-2">
               {movements.map((movement) => {
                 const typeColor = MOVEMENT_TYPE_COLORS[movement.type] || 'bg-gray-500/20 text-gray-400'
                 const posColor = POSITION_COLORS[movement.player.position] || 'text-gray-400'
@@ -289,142 +335,288 @@ export function Movements({ leagueId, onNavigate }: MovementsProps) {
                 const isExpanded = expandedMovement === movement.id
 
                 return (
-                  <div key={movement.id}>
-                    {/* Main Row */}
+                  <div key={movement.id} className="bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden">
+                    {/* Card Header — always visible */}
                     <div
-                      className={`grid grid-cols-12 gap-2 px-4 py-2.5 items-center text-sm hover:bg-surface-300/30 transition-colors cursor-pointer ${isExpanded ? 'bg-surface-300/50' : ''}`}
+                      className={`px-4 py-3 cursor-pointer ${isExpanded ? 'bg-surface-300/30' : ''}`}
                       onClick={() => setExpandedMovement(isExpanded ? null : movement.id)}
                     >
-                      {/* Tipo */}
-                      <div className="col-span-1">
-                        <span className={`px-2 py-0.5 rounded text-xs font-bold ${typeColor}`}>
+                      <div className="flex items-center gap-3">
+                        {/* Type badge */}
+                        <span className={`px-2 py-1 rounded text-xs font-bold flex-shrink-0 ${typeColor}`}>
                           {MOVEMENT_TYPE_SHORT[movement.type] || movement.type.slice(0, 2)}
                         </span>
-                      </div>
 
-                      {/* Stagione */}
-                      <div className="col-span-1 text-xs text-gray-500">
-                        {formatSeason(movement.season || 2025)}
-                      </div>
-
-                      {/* Semestre */}
-                      <div className="col-span-1 text-xs text-gray-500">
-                        {movement.semester || 1}°
-                      </div>
-
-                      {/* Giocatore */}
-                      <div className="col-span-3 flex items-center gap-2">
-                        <div className="w-6 h-6 bg-white rounded flex items-center justify-center p-0.5 flex-shrink-0">
-                          <img
-                            src={getTeamLogo(movement.player.team)}
-                            alt=""
-                            className="w-5 h-5 object-contain"
-                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-                          />
+                        {/* Player info */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <div className="w-5 h-5 bg-white rounded flex items-center justify-center p-0.5 flex-shrink-0">
+                              <img
+                                src={getTeamLogo(movement.player.team)}
+                                alt=""
+                                className="w-4 h-4 object-contain"
+                                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                              />
+                            </div>
+                            <span className={`font-bold text-xs ${posColor}`}>{movement.player.position}</span>
+                            <span className="text-white font-medium text-sm truncate">{movement.player.name}</span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
+                            <span>{formatDate(movement.createdAt)}</span>
+                            <span>•</span>
+                            <span>{movement.from?.username || '—'} → {movement.to?.username || '—'}</span>
+                          </div>
                         </div>
-                        <span className={`font-bold text-xs ${posColor}`}>{movement.player.position}</span>
-                        <span className="text-white font-medium truncate">{movement.player.name}</span>
-                      </div>
 
-                      {/* Da → A */}
-                      <div className="col-span-2 text-xs">
-                        <span className="text-gray-500">{movement.from?.username || '—'}</span>
-                        <span className="text-gray-600 mx-1">→</span>
-                        <span className="text-white">{movement.to?.username || '—'}</span>
-                      </div>
-
-                      {/* Prezzo */}
-                      <div className="col-span-1 text-right">
-                        {movement.price ? (
-                          <span className="text-accent-400 font-semibold">{movement.price}</span>
-                        ) : (
-                          <span className="text-gray-600">—</span>
-                        )}
-                      </div>
-
-                      {/* Contratto */}
-                      <div className="col-span-2 text-xs">
-                        {movement.newContract ? (
-                          <span className="text-gray-300">
-                            {movement.newContract.salary}M × {movement.newContract.duration}sem
-                          </span>
-                        ) : (
-                          <span className="text-gray-600">—</span>
-                        )}
-                      </div>
-
-                      {/* Data */}
-                      <div className="col-span-1 text-right text-xs text-gray-500">
-                        <div>{formatDate(movement.createdAt)}</div>
-                        <div className="text-gray-600">{formatTime(movement.createdAt)}</div>
+                        {/* Price + expand indicator */}
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          {movement.price ? (
+                            <span className="text-accent-400 font-bold text-sm">{movement.price}cr</span>
+                          ) : (
+                            <span className="text-gray-600 text-sm">—</span>
+                          )}
+                          <ChevronDown size={16} className={`text-gray-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+                        </div>
                       </div>
                     </div>
 
-                    {/* Expanded Section - Prophecies */}
+                    {/* Card Expanded Details */}
                     {isExpanded && (
-                      <div className="px-4 py-3 bg-surface-300/30 border-t border-surface-50/10">
-                        <div className="flex items-start gap-4">
-                          {/* Details */}
-                          <div className="flex-1">
-                            <div className="text-xs text-gray-400 mb-2">
-                              <span className="font-semibold">{MOVEMENT_TYPE_LABELS[movement.type]}</span>
-                              {' • '}
-                              {movement.player.team}
-                            </div>
-
-                            {/* Prophecies */}
-                            {hasProphecies && (
-                              <div className="space-y-2 mb-3">
-                                <p className="text-xs font-semibold text-accent-400 uppercase">Profezie</p>
-                                {movement.prophecies.map((p) => (
-                                  <div key={p.id} className="bg-accent-500/10 border border-accent-500/20 rounded-lg p-2">
-                                    <div className="flex items-center gap-2 mb-1">
-                                      <span className="text-xs font-semibold text-white">{p.author.username}</span>
-                                      <span className={`text-[10px] px-1.5 py-0.5 rounded ${p.authorRole === 'BUYER' ? 'bg-secondary-500/20 text-secondary-400' : 'bg-red-500/20 text-red-400'}`}>
-                                        {p.authorRole === 'BUYER' ? 'Acq.' : 'Ven.'}
-                                      </span>
-                                    </div>
-                                    <p className="text-gray-300 text-sm italic">"{p.content}"</p>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-
-                            {/* Add Prophecy */}
-                            {canAdd && (
-                              <div className="mt-2">
-                                <textarea
-                                  value={prophecyContent}
-                                  onChange={(e) => setProphecyContent(e.target.value)}
-                                  placeholder="Scrivi una profezia..."
-                                  className="w-full bg-surface-300 border border-surface-50/30 rounded-lg p-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-accent-500/50"
-                                  rows={2}
-                                  maxLength={500}
-                                />
-                                <div className="flex justify-between items-center mt-2">
-                                  <span className="text-xs text-gray-500">
-                                    {canMakeProphecy[movement.id]?.role === 'BUYER' ? 'Acquirente' : 'Venditore'} • {prophecyContent.length}/500
-                                  </span>
-                                  <Button
-                                    size="sm"
-                                    variant="accent"
-                                    onClick={() => handleAddProphecy(movement.id)}
-                                    disabled={!prophecyContent.trim() || isSubmittingProphecy}
-                                  >
-                                    {isSubmittingProphecy ? '...' : 'Pubblica'}
-                                  </Button>
-                                </div>
-                              </div>
-                            )}
+                      <div className="px-4 py-3 border-t border-surface-50/10 space-y-3">
+                        {/* Detail rows */}
+                        <div className="grid grid-cols-2 gap-2 text-xs">
+                          <div>
+                            <span className="text-gray-500">Tipo</span>
+                            <p className="text-gray-300 font-medium">{MOVEMENT_TYPE_LABELS[movement.type]}</p>
                           </div>
+                          <div>
+                            <span className="text-gray-500">Stagione</span>
+                            <p className="text-gray-300">{formatSeason(movement.season || 2025)} · {movement.semester || 1}° sem</p>
+                          </div>
+                          <div>
+                            <span className="text-gray-500">Squadra reale</span>
+                            <p className="text-gray-300">{movement.player.team}</p>
+                          </div>
+                          {movement.newContract && (
+                            <div>
+                              <span className="text-gray-500">Contratto</span>
+                              <p className="text-gray-300">{movement.newContract.salary}M × {movement.newContract.duration}sem</p>
+                            </div>
+                          )}
                         </div>
+
+                        {/* Prophecies */}
+                        {hasProphecies && (
+                          <div className="space-y-2">
+                            <p className="text-xs font-semibold text-accent-400 uppercase">Profezie</p>
+                            {movement.prophecies.map((p) => (
+                              <div key={p.id} className="bg-accent-500/10 border border-accent-500/20 rounded-lg p-2">
+                                <div className="flex items-center gap-2 mb-1">
+                                  <span className="text-xs font-semibold text-white">{p.author.username}</span>
+                                  <span className={`text-[10px] px-1.5 py-0.5 rounded ${p.authorRole === 'BUYER' ? 'bg-secondary-500/20 text-secondary-400' : 'bg-red-500/20 text-red-400'}`}>
+                                    {p.authorRole === 'BUYER' ? 'Acq.' : 'Ven.'}
+                                  </span>
+                                </div>
+                                <p className="text-gray-300 text-sm italic">"{p.content}"</p>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+
+                        {/* Add Prophecy */}
+                        {canAdd && (
+                          <div>
+                            <textarea
+                              value={prophecyContent}
+                              onChange={(e) => setProphecyContent(e.target.value)}
+                              placeholder="Scrivi una profezia..."
+                              className="w-full bg-surface-300 border border-surface-50/30 rounded-lg p-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-accent-500/50"
+                              rows={2}
+                              maxLength={500}
+                            />
+                            <div className="flex justify-between items-center mt-2">
+                              <span className="text-xs text-gray-500">
+                                {canMakeProphecy[movement.id]?.role === 'BUYER' ? 'Acquirente' : 'Venditore'} • {prophecyContent.length}/500
+                              </span>
+                              <Button
+                                size="sm"
+                                variant="accent"
+                                onClick={() => handleAddProphecy(movement.id)}
+                                disabled={!prophecyContent.trim() || isSubmittingProphecy}
+                              >
+                                {isSubmittingProphecy ? '...' : 'Pubblica'}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>
                 )
               })}
             </div>
-          </div>
+
+            {/* ====== DESKTOP TABLE (md+) ====== */}
+            <div className="hidden md:block bg-surface-200 rounded-xl border border-surface-50/20 overflow-hidden">
+              {/* Table Header */}
+              <div role="row" className="grid grid-cols-12 gap-2 px-4 py-2 bg-surface-300 border-b border-surface-50/20 text-xs font-semibold text-gray-400 uppercase tracking-wide">
+                <div role="columnheader" className="col-span-1">Tipo</div>
+                <div role="columnheader" className="col-span-1">Stag.</div>
+                <div role="columnheader" className="col-span-1">Sem.</div>
+                <div role="columnheader" className="col-span-3">Giocatore</div>
+                <div role="columnheader" className="col-span-2">Da &rarr; A</div>
+                <div role="columnheader" className="col-span-1 text-right">Prezzo</div>
+                <div role="columnheader" className="col-span-2">Contratto</div>
+                <div role="columnheader" className="col-span-1 text-right">Data</div>
+              </div>
+
+              {/* Table Rows */}
+              <div className="divide-y divide-surface-50/10">
+                {movements.map((movement) => {
+                  const typeColor = MOVEMENT_TYPE_COLORS[movement.type] || 'bg-gray-500/20 text-gray-400'
+                  const posColor = POSITION_COLORS[movement.player.position] || 'text-gray-400'
+                  const hasProphecies = movement.prophecies.length > 0
+                  const canAdd = canMakeProphecy[movement.id]?.can
+                  const isExpanded = expandedMovement === movement.id
+
+                  return (
+                    <div key={movement.id}>
+                      {/* Main Row */}
+                      <div
+                        className={`grid grid-cols-12 gap-2 px-4 py-2.5 items-center text-sm hover:bg-surface-300/30 transition-colors cursor-pointer ${isExpanded ? 'bg-surface-300/50' : ''}`}
+                        onClick={() => setExpandedMovement(isExpanded ? null : movement.id)}
+                      >
+                        {/* Tipo */}
+                        <div className="col-span-1">
+                          <span className={`px-2 py-0.5 rounded text-xs font-bold ${typeColor}`}>
+                            {MOVEMENT_TYPE_SHORT[movement.type] || movement.type.slice(0, 2)}
+                          </span>
+                        </div>
+
+                        {/* Stagione */}
+                        <div className="col-span-1 text-xs text-gray-500">
+                          {formatSeason(movement.season || 2025)}
+                        </div>
+
+                        {/* Semestre */}
+                        <div className="col-span-1 text-xs text-gray-500">
+                          {movement.semester || 1}°
+                        </div>
+
+                        {/* Giocatore */}
+                        <div className="col-span-3 flex items-center gap-2">
+                          <div className="w-6 h-6 bg-white rounded flex items-center justify-center p-0.5 flex-shrink-0">
+                            <img
+                              src={getTeamLogo(movement.player.team)}
+                              alt=""
+                              className="w-5 h-5 object-contain"
+                              onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                            />
+                          </div>
+                          <span className={`font-bold text-xs ${posColor}`}>{movement.player.position}</span>
+                          <span className="text-white font-medium truncate">{movement.player.name}</span>
+                        </div>
+
+                        {/* Da → A */}
+                        <div className="col-span-2 text-xs">
+                          <span className="text-gray-500">{movement.from?.username || '—'}</span>
+                          <span className="text-gray-600 mx-1">→</span>
+                          <span className="text-white">{movement.to?.username || '—'}</span>
+                        </div>
+
+                        {/* Prezzo */}
+                        <div className="col-span-1 text-right">
+                          {movement.price ? (
+                            <span className="text-accent-400 font-semibold">{movement.price}</span>
+                          ) : (
+                            <span className="text-gray-600">—</span>
+                          )}
+                        </div>
+
+                        {/* Contratto */}
+                        <div className="col-span-2 text-xs">
+                          {movement.newContract ? (
+                            <span className="text-gray-300">
+                              {movement.newContract.salary}M × {movement.newContract.duration}sem
+                            </span>
+                          ) : (
+                            <span className="text-gray-600">—</span>
+                          )}
+                        </div>
+
+                        {/* Data */}
+                        <div className="col-span-1 text-right text-xs text-gray-500">
+                          <div>{formatDate(movement.createdAt)}</div>
+                          <div className="text-gray-600">{formatTime(movement.createdAt)}</div>
+                        </div>
+                      </div>
+
+                      {/* Expanded Section - Prophecies */}
+                      {isExpanded && (
+                        <div className="px-4 py-3 bg-surface-300/30 border-t border-surface-50/10">
+                          <div className="flex items-start gap-4">
+                            {/* Details */}
+                            <div className="flex-1">
+                              <div className="text-xs text-gray-400 mb-2">
+                                <span className="font-semibold">{MOVEMENT_TYPE_LABELS[movement.type]}</span>
+                                {' • '}
+                                {movement.player.team}
+                              </div>
+
+                              {/* Prophecies */}
+                              {hasProphecies && (
+                                <div className="space-y-2 mb-3">
+                                  <p className="text-xs font-semibold text-accent-400 uppercase">Profezie</p>
+                                  {movement.prophecies.map((p) => (
+                                    <div key={p.id} className="bg-accent-500/10 border border-accent-500/20 rounded-lg p-2">
+                                      <div className="flex items-center gap-2 mb-1">
+                                        <span className="text-xs font-semibold text-white">{p.author.username}</span>
+                                        <span className={`text-[10px] px-1.5 py-0.5 rounded ${p.authorRole === 'BUYER' ? 'bg-secondary-500/20 text-secondary-400' : 'bg-red-500/20 text-red-400'}`}>
+                                          {p.authorRole === 'BUYER' ? 'Acq.' : 'Ven.'}
+                                        </span>
+                                      </div>
+                                      <p className="text-gray-300 text-sm italic">"{p.content}"</p>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+
+                              {/* Add Prophecy */}
+                              {canAdd && (
+                                <div className="mt-2">
+                                  <textarea
+                                    value={prophecyContent}
+                                    onChange={(e) => setProphecyContent(e.target.value)}
+                                    placeholder="Scrivi una profezia..."
+                                    className="w-full bg-surface-300 border border-surface-50/30 rounded-lg p-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-accent-500/50"
+                                    rows={2}
+                                    maxLength={500}
+                                  />
+                                  <div className="flex justify-between items-center mt-2">
+                                    <span className="text-xs text-gray-500">
+                                      {canMakeProphecy[movement.id]?.role === 'BUYER' ? 'Acquirente' : 'Venditore'} • {prophecyContent.length}/500
+                                    </span>
+                                    <Button
+                                      size="sm"
+                                      variant="accent"
+                                      onClick={() => handleAddProphecy(movement.id)}
+                                      disabled={!prophecyContent.trim() || isSubmittingProphecy}
+                                    >
+                                      {isSubmittingProphecy ? '...' : 'Pubblica'}
+                                    </Button>
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </>
         )}
 
         {/* Legend */}

--- a/src/pages/PlayerStats.tsx
+++ b/src/pages/PlayerStats.tsx
@@ -5,7 +5,9 @@ import Card from '../components/ui/Card'
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
 import RadarChart from '../components/ui/RadarChart'
+import { BottomSheet } from '../components/ui/BottomSheet'
 import { getPlayerPhotoUrl, getTeamLogoUrl } from '../utils/player-images'
+import { SlidersHorizontal } from 'lucide-react'
 
 // Position colors
 const POSITION_COLORS: Record<string, string> = {
@@ -168,6 +170,7 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
   const [search, setSearch] = useState('')
   const [positionFilter, setPositionFilter] = useState<string>('')
   const [teamFilter, setTeamFilter] = useState<string>('')
+  const [filtersOpen, setFiltersOpen] = useState(false)
   const [sortBy, setSortBy] = useState<string>('name')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
@@ -404,9 +407,55 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
 
           {/* Filters */}
           <Card className="p-3 md:p-4 mb-4 overflow-x-auto">
-            <div className="flex flex-col sm:flex-row flex-wrap gap-3 md:gap-4 items-stretch sm:items-end min-w-0">
-              {/* Search */}
-              <div className="flex-1 min-w-0 sm:min-w-[180px]">
+            {/* Mobile: search + Filtri button */}
+            <div className="flex flex-col gap-3 md:hidden">
+              <div className="flex gap-2 items-end">
+                <div className="flex-1 min-w-0">
+                  <label className="block text-xs text-gray-400 mb-1">Cerca giocatore</label>
+                  <div className="flex gap-2">
+                    <Input
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      placeholder="Nome..."
+                      onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                      className="min-w-0 flex-1"
+                    />
+                    <Button onClick={handleSearch} variant="outline" className="flex-shrink-0">
+                      🔍
+                    </Button>
+                  </div>
+                </div>
+                <button
+                  onClick={() => setFiltersOpen(true)}
+                  className="flex items-center gap-1.5 px-3 py-2 bg-surface-300 border border-surface-50/30 rounded-lg text-sm text-gray-300 hover:text-white transition-colors flex-shrink-0 mb-px"
+                >
+                  <SlidersHorizontal size={16} />
+                  Filtri{(positionFilter || teamFilter) && (
+                    <span className="ml-0.5 px-1.5 py-0.5 text-[10px] font-bold bg-primary-500/30 text-primary-400 rounded-full">
+                      {[positionFilter, teamFilter].filter(Boolean).length}
+                    </span>
+                  )}
+                </button>
+              </div>
+              {selectedForCompare.size > 0 && (
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => setShowCompareModal(true)}
+                    className="btn-primary flex-1"
+                    disabled={selectedForCompare.size < 2}
+                  >
+                    Confronta ({selectedForCompare.size})
+                  </Button>
+                  <Button onClick={clearComparison} variant="outline" className="flex-shrink-0">
+                    ✕
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            {/* Desktop: full inline filters */}
+            <div className="hidden md:flex flex-wrap gap-4 items-end min-w-0">
+              <div className="flex-1 min-w-0 min-w-[180px]">
                 <label className="block text-xs text-gray-400 mb-1">Cerca giocatore</label>
                 <div className="flex gap-2">
                   <Input
@@ -422,9 +471,8 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                 </div>
               </div>
 
-              {/* Position + Team filters in row on mobile */}
-              <div className="flex gap-2 sm:gap-4">
-                <div className="flex-1 sm:flex-none sm:w-32">
+              <div className="flex gap-4">
+                <div className="w-32">
                   <label className="block text-xs text-gray-400 mb-1">Ruolo</label>
                   <select
                     value={positionFilter}
@@ -442,7 +490,7 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                   </select>
                 </div>
 
-                <div className="flex-1 sm:flex-none sm:w-40">
+                <div className="w-40">
                   <label className="block text-xs text-gray-400 mb-1">Squadra</label>
                   <select
                     value={teamFilter}
@@ -462,12 +510,11 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                 </div>
               </div>
 
-              {/* Compare buttons */}
               {selectedForCompare.size > 0 && (
-                <div className="flex gap-2 w-full sm:w-auto">
+                <div className="flex gap-2">
                   <Button
                     onClick={() => setShowCompareModal(true)}
-                    className="btn-primary flex-1 sm:flex-none"
+                    className="btn-primary"
                     disabled={selectedForCompare.size < 2}
                   >
                     Confronta ({selectedForCompare.size})
@@ -479,6 +526,57 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
               )}
             </div>
           </Card>
+
+          {/* Mobile Filters BottomSheet */}
+          <BottomSheet isOpen={filtersOpen} onClose={() => setFiltersOpen(false)} title="Filtri Statistiche">
+            <div className="p-4 space-y-5">
+              <div>
+                <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Ruolo</label>
+                <div className="flex gap-2">
+                  {['', 'P', 'D', 'C', 'A'].map(pos => (
+                    <button
+                      key={pos}
+                      onClick={() => {
+                        setPositionFilter(pos)
+                        setPage(1)
+                      }}
+                      className={`flex-1 px-3 py-2.5 text-sm font-medium rounded-lg transition-colors ${
+                        positionFilter === pos
+                          ? 'bg-primary-500/30 text-primary-400'
+                          : 'bg-surface-300 text-gray-400'
+                      }`}
+                    >
+                      {pos === '' ? 'Tutti' : pos}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Squadra</label>
+                <select
+                  value={teamFilter}
+                  onChange={(e) => {
+                    setTeamFilter(e.target.value)
+                    setPage(1)
+                  }}
+                  className="w-full px-3 py-2.5 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  <option value="">Tutte le squadre</option>
+                  {teams.map((team) => (
+                    <option key={team} value={team}>{team}</option>
+                  ))}
+                </select>
+              </div>
+
+              <button
+                onClick={() => setFiltersOpen(false)}
+                className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors"
+              >
+                Applica Filtri
+              </button>
+            </div>
+          </BottomSheet>
 
           {/* Column Selector & Presets */}
           <Card className="p-3 md:p-4 mb-4 overflow-x-auto">

--- a/src/pages/PlayerStats.tsx
+++ b/src/pages/PlayerStats.tsx
@@ -396,7 +396,7 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
         <div className="max-w-[1800px] mx-auto">
           {/* Header */}
           <div className="mb-6">
-            <h1 className="text-2xl font-bold text-white mb-2">Statistiche Serie A</h1>
+            <h1 className="text-xl md:text-2xl font-bold text-white mb-2">Statistiche Serie A</h1>
             <p className="text-gray-400">
               Analizza le statistiche dei giocatori della Serie A ({total} giocatori con dati)
             </p>
@@ -590,7 +590,7 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                   <table className="w-full min-w-[800px]">
                     <thead className="bg-surface-300 sticky top-0">
                       <tr>
-                        <th className="px-3 py-3 text-left text-xs font-medium text-gray-400 w-10">
+                        <th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-400 w-10">
                           <input
                             type="checkbox"
                             className="rounded"
@@ -599,24 +599,32 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                           />
                         </th>
                         <th
+                          scope="col"
+                          aria-sort={sortBy === 'name' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
                           className="px-3 py-3 text-left text-xs font-medium text-gray-400 cursor-pointer hover:text-white min-w-[180px]"
                           onClick={() => handleSort('name')}
                         >
                           Giocatore <SortIcon column="name" />
                         </th>
                         <th
+                          scope="col"
+                          aria-sort={sortBy === 'team' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
                           className="px-3 py-3 text-left text-xs font-medium text-gray-400 cursor-pointer hover:text-white min-w-[120px]"
                           onClick={() => handleSort('team')}
                         >
                           Squadra <SortIcon column="team" />
                         </th>
                         <th
+                          scope="col"
+                          aria-sort={sortBy === 'position' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
                           className="px-3 py-3 text-center text-xs font-medium text-gray-400 cursor-pointer hover:text-white w-16"
                           onClick={() => handleSort('position')}
                         >
                           Pos <SortIcon column="position" />
                         </th>
                         <th
+                          scope="col"
+                          aria-sort={sortBy === 'quotation' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
                           className="px-3 py-3 text-center text-xs font-medium text-gray-400 cursor-pointer hover:text-white w-16"
                           onClick={() => handleSort('quotation')}
                         >
@@ -626,6 +634,8 @@ export default function PlayerStats({ leagueId, onNavigate }: PlayerStatsProps) 
                         {visibleColumnDefs.map(col => (
                           <th
                             key={col.key}
+                            scope="col"
+                            aria-sort={col.sortable && sortBy === col.key ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
                             className="px-2 py-3 text-center text-xs font-medium text-gray-400 cursor-pointer hover:text-white whitespace-nowrap"
                             onClick={() => col.sortable && handleSort(col.key)}
                             title={col.label}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -223,6 +223,7 @@ export function Profile({ onNavigate }: ProfileProps) {
                   ref={fileInputRef}
                   type="file"
                   accept="image/*"
+                  capture="user"
                   className="hidden"
                   onChange={handlePhotoChange}
                 />

--- a/src/pages/Prophecies.tsx
+++ b/src/pages/Prophecies.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { historyApi, leagueApi } from '../services/api'
 import { Navigation } from '../components/Navigation'
+import { EmptyState } from '../components/ui/EmptyState'
 
 interface Prophecy {
   id: string
@@ -224,10 +225,10 @@ export function Prophecies({ leagueId, onNavigate }: PropheciesProps) {
     <div className="min-h-screen bg-dark-300">
       <Navigation currentPage="prophecies" leagueId={leagueId} isLeagueAdmin={isLeagueAdmin} onNavigate={onNavigate} />
 
-      <main className="max-w-[1600px] mx-auto px-4 py-6">
+      <main className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">
         {/* Header compatto */}
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+          <h1 className="text-xl md:text-2xl font-bold text-white flex items-center gap-2">
             <span>🔮</span>
             Profezie
             <span className="text-base font-normal text-gray-400">
@@ -241,6 +242,7 @@ export function Prophecies({ leagueId, onNavigate }: PropheciesProps) {
               onClick={() => setShowStats(!showStats)}
               className={`p-2 rounded-lg transition-colors ${showStats ? 'bg-purple-500/20 text-purple-400' : 'text-gray-400 hover:text-white'}`}
               title={showStats ? 'Nascondi statistiche' : 'Mostra statistiche'}
+              aria-label={showStats ? 'Nascondi statistiche' : 'Mostra statistiche'}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
@@ -252,6 +254,7 @@ export function Prophecies({ leagueId, onNavigate }: PropheciesProps) {
               onClick={() => setCompactView(!compactView)}
               className={`p-2 rounded-lg transition-colors ${compactView ? 'text-gray-400 hover:text-white' : 'bg-primary-500/20 text-primary-400'}`}
               title={compactView ? 'Vista espansa' : 'Vista compatta'}
+              aria-label={compactView ? 'Vista espansa' : 'Vista compatta'}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 {compactView ? (
@@ -375,29 +378,30 @@ export function Prophecies({ leagueId, onNavigate }: PropheciesProps) {
             <div className="w-8 h-8 border-2 border-primary-500/30 border-t-primary-500 rounded-full animate-spin"></div>
           </div>
         ) : prophecies.length === 0 ? (
-          <div className="bg-surface-200 rounded-lg border border-surface-50/20 p-8 text-center">
-            <span className="text-4xl mb-3 block">🔮</span>
-            <p className="text-gray-400 text-sm">Nessuna profezia trovata</p>
-            {hasActiveFilters && (
+          <EmptyState
+            icon="🔮"
+            title="Nessuna profezia trovata"
+            description={hasActiveFilters ? "Prova a cambiare i filtri di ricerca." : undefined}
+            action={hasActiveFilters ? (
               <button
                 onClick={clearFilters}
-                className="mt-3 px-4 py-2 text-sm bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors"
+                className="px-4 py-2 text-sm bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors"
               >
                 Resetta filtri
               </button>
-            )}
-          </div>
+            ) : undefined}
+          />
         ) : compactView ? (
           /* Vista Compatta - Tabella */
           <div className="bg-surface-200 rounded-lg border border-surface-50/20 overflow-hidden">
             <table className="w-full text-sm">
               <thead className="bg-surface-300/50 border-b border-surface-50/20">
                 <tr>
-                  <th className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase">Giocatore</th>
-                  <th className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden lg:table-cell">Profezia</th>
-                  <th className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase">Autore</th>
-                  <th className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden sm:table-cell">Evento</th>
-                  <th className="text-right px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden sm:table-cell">Prezzo</th>
+                  <th scope="col" className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase">Giocatore</th>
+                  <th scope="col" className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden lg:table-cell">Profezia</th>
+                  <th scope="col" className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase">Autore</th>
+                  <th scope="col" className="text-left px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden sm:table-cell">Evento</th>
+                  <th scope="col" className="text-right px-3 py-2 text-xs font-semibold text-gray-400 uppercase hidden sm:table-cell">Prezzo</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-surface-50/10">

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -94,6 +94,8 @@ export function Register({ onNavigate }: RegisterProps) {
             <Input
               label="Email"
               type="email"
+              inputMode="email"
+              autoComplete="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
               placeholder="mario@email.com"

--- a/src/pages/Rose.tsx
+++ b/src/pages/Rose.tsx
@@ -227,10 +227,17 @@ export function Rose({ onNavigate }: RoseProps) {
     return (
       <div className="min-h-screen bg-dark-300">
         <Navigation currentPage="rose" leagueId={leagueId} isLeagueAdmin={isLeagueAdmin} onNavigate={onNavigate} />
-        <main className="max-w-[1600px] mx-auto px-4 py-8">
-          <div className="flex items-center justify-center py-20">
-            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-400"></div>
-          </div>
+        <main className="max-w-[1600px] mx-auto px-4 py-8 space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 p-3 bg-surface-200/50 rounded-lg animate-pulse">
+              <div className="w-10 h-10 rounded-full bg-surface-100" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-32 bg-surface-100 rounded" />
+                <div className="h-3 w-20 bg-surface-100 rounded" />
+              </div>
+              <div className="h-6 w-16 bg-surface-100 rounded" />
+            </div>
+          ))}
         </main>
       </div>
     )
@@ -371,7 +378,29 @@ export function Rose({ onNavigate }: RoseProps) {
                     onChange={(e) => setSearchQuery(e.target.value)}
                     placeholder="Cerca giocatore..."
                     className="flex-1 min-w-[120px] px-2 py-1 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-xs"
+                    inputMode="search"
+                    enterKeyHint="search"
                   />
+                </div>
+                {/* Duration color legend */}
+                <div className="flex items-center gap-3 text-xs text-gray-400 mt-2 flex-wrap">
+                  <span>Durata:</span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-gradient-to-r from-red-500 to-red-600" />
+                    1 sem
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-gradient-to-r from-yellow-500 to-yellow-600" />
+                    2 sem
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-gradient-to-r from-green-500 to-green-600" />
+                    3 sem
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-gradient-to-r from-blue-500 to-blue-600" />
+                    4+ sem
+                  </span>
                 </div>
               </div>
 
@@ -489,17 +518,17 @@ export function Rose({ onNavigate }: RoseProps) {
                 <table className="w-full min-w-[600px] text-sm table-fixed">
                   <thead className="bg-surface-300/50">
                     <tr className="text-xs text-gray-400 uppercase">
-                      <th className="w-12 p-2 text-center">R</th>
-                      <th className="w-auto text-left p-2">Giocatore</th>
-                      <th className="w-36 text-left p-2">Squadra</th>
-                      <th className="w-10 text-center p-2" title="Presenze">Pr</th>
-                      <th className="w-10 text-center p-2" title="Gol">G</th>
-                      <th className="w-10 text-center p-2" title="Assist">A</th>
-                      <th className="w-12 text-center p-2" title="Rating">Vt</th>
-                      <th className="w-16 text-center p-2 text-accent-400">Ing</th>
-                      <th className="w-14 text-center p-2">Dur</th>
-                      <th className="w-16 text-center p-2 text-orange-400">Cls</th>
-                      <th className="w-16 text-center p-2 text-warning-400">Rub</th>
+                      <th scope="col" className="w-12 p-2 text-center">R</th>
+                      <th scope="col" className="w-auto text-left p-2">Giocatore</th>
+                      <th scope="col" className="w-36 text-left p-2">Squadra</th>
+                      <th scope="col" className="w-10 text-center p-2" title="Presenze">Pr</th>
+                      <th scope="col" className="w-10 text-center p-2" title="Gol">G</th>
+                      <th scope="col" className="w-10 text-center p-2" title="Assist">A</th>
+                      <th scope="col" className="w-12 text-center p-2" title="Rating">Vt</th>
+                      <th scope="col" className="w-16 text-center p-2 text-accent-400">Ing</th>
+                      <th scope="col" className="w-14 text-center p-2">Dur</th>
+                      <th scope="col" className="w-16 text-center p-2 text-orange-400">Cls</th>
+                      <th scope="col" className="w-16 text-center p-2 text-warning-400">Rub</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/src/pages/Rose.tsx
+++ b/src/pages/Rose.tsx
@@ -4,7 +4,9 @@ import { leagueApi } from '../services/api'
 import { Navigation } from '../components/Navigation'
 import { getTeamLogo } from '../utils/teamLogos'
 import { POSITION_COLORS } from '../components/ui/PositionBadge'
+import { BottomSheet } from '../components/ui/BottomSheet'
 import { PlayerStatsModal, type PlayerInfo, type PlayerStats } from '../components/PlayerStatsModal'
+import { SlidersHorizontal } from 'lucide-react'
 
 interface RoseProps {
   onNavigate: (page: string, params?: Record<string, string>) => void
@@ -106,6 +108,7 @@ export function Rose({ onNavigate }: RoseProps) {
   const [positionFilter, setPositionFilter] = useState<string>('ALL')
   const [searchQuery, setSearchQuery] = useState('')
   const [teamFilter, setTeamFilter] = useState<string>('ALL')
+  const [filtersOpen, setFiltersOpen] = useState(false)
 
   // Stats modal
   const [selectedPlayerStats, setSelectedPlayerStats] = useState<PlayerInfo | null>(null)
@@ -332,9 +335,34 @@ export function Rose({ onNavigate }: RoseProps) {
                 </div>
               </div>
 
-              {/* Filters Row */}
+              {/* Filters Row — Mobile: compact search + Filtri button */}
               <div className="p-3 border-b border-surface-50/20 bg-surface-300/20">
-                <div className="flex flex-wrap gap-2 items-center">
+                {/* Mobile compact */}
+                <div className="flex gap-2 items-center md:hidden">
+                  <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Cerca giocatore..."
+                    className="flex-1 min-w-0 px-2 py-1.5 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-xs"
+                    inputMode="search"
+                    enterKeyHint="search"
+                  />
+                  <button
+                    onClick={() => setFiltersOpen(true)}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 bg-surface-300 border border-surface-50/30 rounded-lg text-xs text-gray-300 hover:text-white transition-colors flex-shrink-0"
+                  >
+                    <SlidersHorizontal size={14} />
+                    Filtri{(positionFilter !== 'ALL' || teamFilter !== 'ALL') && (
+                      <span className="ml-0.5 px-1.5 py-0.5 text-[10px] font-bold bg-primary-500/30 text-primary-400 rounded-full">
+                        {[positionFilter !== 'ALL', teamFilter !== 'ALL'].filter(Boolean).length}
+                      </span>
+                    )}
+                  </button>
+                </div>
+
+                {/* Desktop: full inline filters */}
+                <div className="hidden md:flex flex-wrap gap-2 items-center">
                   {/* Position Filter */}
                   <div className="flex gap-1">
                     {['ALL', 'P', 'D', 'C', 'A'].map(pos => {
@@ -403,6 +431,58 @@ export function Rose({ onNavigate }: RoseProps) {
                   </span>
                 </div>
               </div>
+
+              {/* Mobile Filters BottomSheet */}
+              <BottomSheet isOpen={filtersOpen} onClose={() => setFiltersOpen(false)} title="Filtri">
+                <div className="p-4 space-y-5">
+                  <div>
+                    <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Posizione</label>
+                    <div className="flex gap-2">
+                      {['ALL', 'P', 'D', 'C', 'A'].map(pos => {
+                        const colors = POSITION_COLORS[pos]
+                        return (
+                          <button
+                            key={pos}
+                            onClick={() => setPositionFilter(pos)}
+                            className={`flex-1 px-3 py-2.5 text-sm font-medium rounded-lg transition-all ${
+                              positionFilter === pos
+                                ? pos === 'ALL'
+                                  ? 'bg-white/20 text-white'
+                                  : `${colors?.bg} ${colors?.text}`
+                                : 'bg-surface-300 text-gray-500'
+                            }`}
+                          >
+                            {pos === 'ALL' ? 'Tutti' : pos}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+
+                  {uniqueTeams.length > 0 && (
+                    <div>
+                      <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Squadra Serie A</label>
+                      <select
+                        value={teamFilter}
+                        onChange={(e) => setTeamFilter(e.target.value)}
+                        className="w-full px-3 py-2.5 bg-surface-300 border border-surface-50/30 rounded-lg text-white text-sm"
+                      >
+                        <option value="ALL">Tutte le squadre</option>
+                        {uniqueTeams.map(team => (
+                          <option key={team} value={team}>{team}</option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+
+                  <button
+                    onClick={() => setFiltersOpen(false)}
+                    className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors"
+                  >
+                    Applica Filtri
+                  </button>
+                </div>
+              </BottomSheet>
 
               {/* Stats Bar */}
               {selectedMember && (

--- a/src/pages/Trades.tsx
+++ b/src/pages/Trades.tsx
@@ -7,6 +7,7 @@ import { getTeamLogo } from '../utils/teamLogos'
 import { getPlayerPhotoUrl } from '../utils/player-images'
 import { POSITION_GRADIENTS } from '../components/ui/PositionBadge'
 import { ContractModifierModal, type PlayerInfo, type ContractData } from '../components/ContractModifier'
+import { EmptyState } from '../components/ui/EmptyState'
 
 interface TradesProps {
   leagueId: string
@@ -920,17 +921,7 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
         {activeTab === 'received' && (
           <div className="space-y-6">
             {receivedOffers.length === 0 ? (
-              <Card className="border-dashed border-2 border-surface-50/30">
-                <CardContent className="py-12 text-center">
-                  <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-surface-300 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-                    </svg>
-                  </div>
-                  <p className="text-gray-500 text-lg">Nessuna offerta ricevuta</p>
-                  <p className="text-gray-600 text-sm mt-1">Le offerte che riceverai appariranno qui</p>
-                </CardContent>
-              </Card>
+              <EmptyState icon="📥" title="Nessuna offerta ricevuta" description="Le offerte che riceverai appariranno qui" />
             ) : (
               receivedOffers.map(offer => {
                 const timeRemaining = getTimeRemaining(offer.expiresAt)
@@ -1067,17 +1058,7 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
         {activeTab === 'sent' && (
           <div className="space-y-6">
             {sentOffers.length === 0 ? (
-              <Card className="border-dashed border-2 border-surface-50/30">
-                <CardContent className="py-12 text-center">
-                  <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-surface-300 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-                    </svg>
-                  </div>
-                  <p className="text-gray-500 text-lg">Nessuna offerta inviata</p>
-                  <p className="text-gray-600 text-sm mt-1">Le tue offerte appariranno qui</p>
-                </CardContent>
-              </Card>
+              <EmptyState icon="📤" title="Nessuna offerta inviata" description="Le tue offerte appariranno qui" />
             ) : (
               sentOffers.map(offer => {
                 const timeRemaining = getTimeRemaining(offer.expiresAt)
@@ -1828,17 +1809,7 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
               </div>
 
               {timelineItems.length === 0 ? (
-                <Card className="border-dashed border-2 border-surface-50/30">
-                  <CardContent className="py-12 text-center">
-                    <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-surface-300 flex items-center justify-center">
-                      <svg className="w-8 h-8 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    </div>
-                    <p className="text-gray-500 text-lg">Nessun elemento nello storico</p>
-                    <p className="text-gray-600 text-sm mt-1">Gli scambi completati, rifiutati e i movimenti appariranno qui</p>
-                  </CardContent>
-                </Card>
+                <EmptyState icon="🕐" title="Nessun elemento nello storico" description="Gli scambi completati, rifiutati e i movimenti appariranno qui" />
               ) : (
                 <div className="space-y-4">
                   {timelineItems.map(item => {


### PR DESCRIPTION
## Summary

- **TASK-001**: `DataTable` responsive component — desktop table, tablet horizontal scroll, mobile card view con sorting e paginazione
- **TASK-007**: Migrazione completa SVG inline → lucide-react (Navigation, Modal, BottomSheet, ScrollToTop, ThemeSelector, LandscapeHint)
- **TASK-004**: Movements mobile card view con expand/collapse e filtri responsive
- **TASK-015**: `Tooltip` component (hover desktop, tap mobile) + tooltip informativi su 5 badge contratto (SPALMATO, SPALMABILE, DA TAGLIARE, MANTENUTO, SCAMBIO)
- **MOB-001**: `BottomNavBar` con 5 tab (Home, Asta, Rosa, Finanze, Menu), scroll hide/show, badge LIVE su asta, integrato in App.tsx via custom DOM event
- **MOB-009**: `StickyActionBar` posizionato sopra BottomNavBar su mobile (`bottom-14 md:bottom-0`), applicato al footer budget di Contracts
- **MOB-011**: Filtri collassati in BottomSheet su mobile per AllPlayers, Rose, Movements, PlayerStats — search sempre visibile + bottone "Filtri (N)" con conteggio filtri attivi

## Nuovi componenti
- `src/components/BottomNavBar.tsx`
- `src/components/ui/DataTable.tsx`
- `src/components/ui/Tooltip.tsx`
- `src/components/ui/StickyActionBar.tsx`

## Test plan
- [ ] BottomNavBar visibile su mobile (<768px) nelle pagine di lega, nascosto su desktop
- [ ] Tab Menu apre il drawer laterale di Navigation
- [ ] Scroll down nasconde la bottom nav, scroll up la mostra
- [ ] Badge LIVE su tab Asta quando si è in /auction
- [ ] Filtri BottomSheet su AllPlayers, Rose, Movements, PlayerStats (mobile)
- [ ] Badge conteggio filtri attivi corretto
- [ ] Desktop: filtri inline invariati
- [ ] Tooltip su badge contratto (hover desktop, tap mobile)
- [ ] StickyActionBar in Contracts sopra la bottom nav su mobile
- [ ] Movements card view su mobile con expand/collapse
- [ ] Icone lucide-react corrette in Navigation, Modal, BottomSheet, ScrollToTop, ThemeSelector

🤖 Generated with [Claude Code](https://claude.com/claude-code)