### PR TITLE
feat: Sprint Combinato 3 - Core Refactoring + Mobile Interactions

### DIFF
--- a/src/components/rubata/PreferenceModal.tsx
+++ b/src/components/rubata/PreferenceModal.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react'
+import { Button } from '../ui/Button'
+import { getTeamLogo } from '../../utils/teamLogos'
+
+function TeamLogo({ team }: { team: string }) {
+  return (
+    <img
+      src={getTeamLogo(team)}
+      alt={team}
+      className="w-full h-full object-contain"
+      onError={(e) => {
+        (e.target as HTMLImageElement).style.display = 'none'
+      }}
+    />
+  )
+}
+
+interface RubataPreference {
+  id: string
+  playerId: string
+  isWatchlist: boolean
+  isAutoPass: boolean
+  maxBid: number | null
+  priority: number | null
+  notes: string | null
+}
+
+interface BoardPlayerBase {
+  rosterId: string
+  playerName: string
+  playerTeam: string
+  rubataPrice: number
+  preference?: RubataPreference | null
+}
+
+export interface PreferenceModalProps {
+  player: BoardPlayerBase
+  onClose: () => void
+  onSave: (data: { maxBid: number | null; priority: number | null; notes: string | null }) => Promise<void>
+  onDelete: () => Promise<void>
+  isSubmitting: boolean
+}
+
+export function PreferenceModal({ player, onClose, onSave, onDelete, isSubmitting }: PreferenceModalProps) {
+  const [formData, setFormData] = useState({
+    maxBid: player.preference?.maxBid?.toString() || '',
+    priority: player.preference?.priority?.toString() || '',
+    notes: player.preference?.notes || '',
+  })
+
+  const handleSave = async () => {
+    await onSave({
+      maxBid: formData.maxBid ? parseInt(formData.maxBid) : null,
+      priority: formData.priority ? parseInt(formData.priority) : null,
+      notes: formData.notes || null,
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-fadeIn">
+      <div className="bg-surface-200 rounded-2xl p-6 max-w-md w-full shadow-2xl border border-indigo-500/50">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 bg-white rounded p-1">
+            <TeamLogo team={player.playerTeam} />
+          </div>
+          <div>
+            <h3 className="font-bold text-white">{player.playerName}</h3>
+            <p className="text-sm text-gray-400">{player.playerTeam} • {player.rubataPrice}M</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto w-8 h-8 min-h-[44px] min-w-[44px] rounded-full bg-surface-300 text-gray-400 hover:bg-surface-50/20 flex items-center justify-center"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Form */}
+        <div className="space-y-4">
+          {/* Max bid with +/- buttons */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">Budget massimo</label>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setFormData(p => ({
+                  ...p,
+                  maxBid: String(Math.max(0, (parseInt(p.maxBid) || 0) - 5))
+                }))}
+                disabled={!formData.maxBid || parseInt(formData.maxBid) <= 0}
+                className="w-10 h-10 min-h-[44px] min-w-[44px] rounded-lg bg-surface-300 border border-surface-50/30 text-white text-xl font-bold hover:bg-surface-50/20 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                −
+              </button>
+              <div className="flex-1 text-center">
+                <input
+                  type="number"
+                  value={formData.maxBid}
+                  onChange={e => setFormData(p => ({ ...p, maxBid: e.target.value }))}
+                  placeholder="—"
+                  className="w-full text-center text-2xl font-bold bg-transparent text-white focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                />
+                <p className="text-xs text-gray-500">milioni</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setFormData(p => ({
+                  ...p,
+                  maxBid: String((parseInt(p.maxBid) || 0) + 5)
+                }))}
+                className="w-10 h-10 min-h-[44px] min-w-[44px] rounded-lg bg-surface-300 border border-surface-50/30 text-white text-xl font-bold hover:bg-surface-50/20 transition-all"
+              >
+                +
+              </button>
+            </div>
+            {formData.maxBid && (
+              <button
+                type="button"
+                onClick={() => setFormData(p => ({ ...p, maxBid: '' }))}
+                className="mt-1 text-xs text-gray-500 hover:text-gray-400"
+              >
+                Rimuovi limite
+              </button>
+            )}
+          </div>
+
+          {/* Priority with star rating */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">Priorità</label>
+            <div className="flex items-center justify-center gap-1">
+              {[1, 2, 3, 4, 5].map(star => {
+                const currentPriority = parseInt(formData.priority) || 0
+                const isActive = star <= currentPriority
+                return (
+                  <button
+                    type="button"
+                    key={star}
+                    onClick={() => setFormData(p => ({
+                      ...p,
+                      priority: p.priority === String(star) ? '' : String(star)
+                    }))}
+                    className={`w-10 h-10 min-h-[44px] min-w-[44px] text-2xl transition-all transform hover:scale-110 ${
+                      isActive ? 'text-purple-400' : 'text-gray-600 hover:text-purple-400/50'
+                    }`}
+                    title={`Priorità ${star}`}
+                  >
+                    {isActive ? '★' : '☆'}
+                  </button>
+                )
+              })}
+            </div>
+            <p className="text-center text-xs text-gray-500 mt-1">
+              {formData.priority ? `Priorità ${formData.priority} (clicca per rimuovere)` : 'Clicca per impostare'}
+            </p>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Note private</label>
+            <textarea
+              value={formData.notes}
+              onChange={e => setFormData(p => ({ ...p, notes: e.target.value }))}
+              placeholder="Appunti personali..."
+              rows={3}
+              className="w-full px-3 py-2 bg-surface-300 border border-surface-50/20 rounded-lg text-white placeholder-gray-500 focus:border-indigo-500/50 focus:outline-none resize-none"
+            />
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 mt-6">
+          {player.preference && (
+            <Button
+              onClick={onDelete}
+              disabled={isSubmitting}
+              variant="outline"
+              className="border-danger-500/50 text-danger-400 hover:bg-danger-500/10"
+            >
+              Rimuovi
+            </Button>
+          )}
+          <Button onClick={onClose} variant="outline" className="flex-1">
+            Annulla
+          </Button>
+          <Button onClick={handleSave} disabled={isSubmitting} className="flex-1">
+            Salva
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PreferenceModal

--- a/src/components/rubata/RubataStepper.tsx
+++ b/src/components/rubata/RubataStepper.tsx
@@ -1,0 +1,118 @@
+type RubataState = 'WAITING' | 'PREVIEW' | 'READY_CHECK' | 'OFFERING' | 'AUCTION_READY_CHECK' | 'AUCTION' | 'PENDING_ACK' | 'PAUSED' | 'COMPLETED' | null
+
+interface RubataStepperProps {
+  currentState: RubataState
+  className?: string
+}
+
+const STEPS = [
+  { key: 'WAITING', label: 'Attesa', shortLabel: 'Att.', icon: '⏹️', color: 'primary' },
+  { key: 'PREVIEW', label: 'Preview', shortLabel: 'Prev.', icon: '👁️', color: 'indigo' },
+  { key: 'READY_CHECK', label: 'Pronti?', shortLabel: 'Pronti', icon: '🔔', color: 'blue' },
+  { key: 'OFFERING', label: 'Offerta', shortLabel: 'Off.', icon: '⏳', color: 'warning' },
+  { key: 'AUCTION', label: 'Asta', shortLabel: 'Asta', icon: '🔥', color: 'danger' },
+  { key: 'PENDING_ACK', label: 'Conferma', shortLabel: 'Conf.', icon: '✋', color: 'purple' },
+] as const
+
+// Map from AUCTION_READY_CHECK to AUCTION step (it's a sub-step before auction)
+function getEffectiveStep(state: RubataState): string {
+  if (state === 'AUCTION_READY_CHECK') return 'AUCTION'
+  if (state === 'PAUSED') return 'OFFERING' // Paused during offering
+  return state || 'WAITING'
+}
+
+function getStepIndex(state: RubataState): number {
+  const effective = getEffectiveStep(state)
+  const idx = STEPS.findIndex(s => s.key === effective)
+  return idx >= 0 ? idx : 0
+}
+
+const COLOR_MAP: Record<string, { bg: string; border: string; text: string; dot: string }> = {
+  primary: { bg: 'bg-primary-500/20', border: 'border-primary-500', text: 'text-primary-400', dot: 'bg-primary-500' },
+  indigo: { bg: 'bg-indigo-500/20', border: 'border-indigo-500', text: 'text-indigo-400', dot: 'bg-indigo-500' },
+  blue: { bg: 'bg-blue-500/20', border: 'border-blue-500', text: 'text-blue-400', dot: 'bg-blue-500' },
+  warning: { bg: 'bg-warning-500/20', border: 'border-warning-500', text: 'text-warning-400', dot: 'bg-warning-500' },
+  danger: { bg: 'bg-danger-500/20', border: 'border-danger-500', text: 'text-danger-400', dot: 'bg-danger-500' },
+  purple: { bg: 'bg-purple-500/20', border: 'border-purple-500', text: 'text-purple-400', dot: 'bg-purple-500' },
+}
+
+export function RubataStepper({ currentState, className = '' }: RubataStepperProps) {
+  if (currentState === 'COMPLETED') {
+    return (
+      <div className={`flex items-center justify-center gap-2 py-2 px-4 rounded-xl bg-secondary-500/20 border border-secondary-500/40 ${className}`}>
+        <span>✅</span>
+        <span className="text-secondary-400 font-bold text-sm">Rubata Completata</span>
+      </div>
+    )
+  }
+
+  const activeIndex = getStepIndex(currentState)
+
+  return (
+    <div className={`${className}`}>
+      {/* Desktop: full stepper */}
+      <div className="hidden md:flex items-center gap-1">
+        {STEPS.map((step, i) => {
+          const isActive = i === activeIndex
+          const isCompleted = i < activeIndex
+          const colors = COLOR_MAP[step.color]
+
+          return (
+            <div key={step.key} className="flex items-center">
+              {/* Step */}
+              <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
+                isActive
+                  ? `${colors.bg} ${colors.text} border ${colors.border}/40 shadow-sm`
+                  : isCompleted
+                    ? 'bg-surface-300/50 text-gray-500 line-through'
+                    : 'bg-surface-300/30 text-gray-600'
+              }`}>
+                <span className="text-sm">{isActive ? step.icon : isCompleted ? '✓' : '○'}</span>
+                <span>{step.label}</span>
+              </div>
+              {/* Connector */}
+              {i < STEPS.length - 1 && (
+                <div className={`w-4 h-0.5 mx-0.5 ${
+                  i < activeIndex ? 'bg-gray-600' : 'bg-surface-300/30'
+                }`} />
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Mobile: compact dots + current label */}
+      <div className="flex md:hidden items-center gap-2 px-3 py-2 rounded-xl bg-surface-200 border border-surface-50/20">
+        <div className="flex items-center gap-1">
+          {STEPS.map((step, i) => {
+            const isActive = i === activeIndex
+            const isCompleted = i < activeIndex
+            const colors = COLOR_MAP[step.color]
+
+            return (
+              <div
+                key={step.key}
+                className={`rounded-full transition-all ${
+                  isActive
+                    ? `w-3 h-3 ${colors.dot} shadow-lg animate-pulse`
+                    : isCompleted
+                      ? 'w-2 h-2 bg-gray-500'
+                      : 'w-2 h-2 bg-surface-300'
+                }`}
+              />
+            )
+          })}
+        </div>
+        <div className="flex items-center gap-1.5 text-sm">
+          <span>{STEPS[activeIndex]?.icon}</span>
+          <span className={`font-bold ${COLOR_MAP[STEPS[activeIndex]?.color]?.text || 'text-gray-400'}`}>
+            {STEPS[activeIndex]?.label || currentState}
+          </span>
+          <span className="text-gray-600 text-xs">({activeIndex + 1}/{STEPS.length})</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RubataStepper

--- a/src/components/rubata/index.ts
+++ b/src/components/rubata/index.ts
@@ -1,0 +1,2 @@
+export { RubataStepper } from './RubataStepper'
+export { PreferenceModal } from './PreferenceModal'

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -135,7 +135,7 @@ export function BottomSheet({
               </h2>
               <button
                 onClick={onClose}
-                className="p-2 text-gray-400 hover:text-white rounded-lg hover:bg-surface-100 transition-colors"
+                className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-400 hover:text-white rounded-lg hover:bg-surface-100 transition-colors"
                 aria-label="Chiudi"
               >
                 <X size={20} />

--- a/src/components/ui/DurationSlider.tsx
+++ b/src/components/ui/DurationSlider.tsx
@@ -68,7 +68,7 @@ export function DurationSlider({
                 key={mark}
                 onClick={() => handleChange(mark)}
                 disabled={disabled}
-                className={`text-xs font-medium transition-colors ${
+                className={`text-xs font-medium transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center ${
                   value === mark
                     ? 'text-primary-400'
                     : 'text-gray-500 hover:text-gray-300'
@@ -124,7 +124,7 @@ export function DurationSliderCompact({
       <button
         onClick={() => handleChange(value - 1)}
         disabled={disabled || value <= min || (!canDecrease && value <= min)}
-        className="w-8 h-8 flex items-center justify-center rounded bg-surface-300 text-white font-bold disabled:opacity-30 disabled:cursor-not-allowed hover:bg-surface-100 transition-colors min-h-[44px]"
+        className="w-8 h-8 flex items-center justify-center rounded bg-surface-300 text-white font-bold disabled:opacity-30 disabled:cursor-not-allowed hover:bg-surface-100 transition-colors min-h-[44px] min-w-[44px]"
         aria-label="Riduci durata"
       >
         −
@@ -135,7 +135,7 @@ export function DurationSliderCompact({
       <button
         onClick={() => handleChange(value + 1)}
         disabled={disabled || value >= max}
-        className="w-8 h-8 flex items-center justify-center rounded bg-surface-300 text-white font-bold disabled:opacity-30 disabled:cursor-not-allowed hover:bg-surface-100 transition-colors min-h-[44px]"
+        className="w-8 h-8 flex items-center justify-center rounded bg-surface-300 text-white font-bold disabled:opacity-30 disabled:cursor-not-allowed hover:bg-surface-100 transition-colors min-h-[44px] min-w-[44px]"
         aria-label="Aumenta durata"
       >
         +

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -128,7 +128,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(
               onClick={onClose}
               className="
                 absolute top-4 right-4 z-10
-                w-8 h-8 flex items-center justify-center
+                w-8 h-8 min-h-[44px] min-w-[44px] flex items-center justify-center
                 rounded-lg text-gray-400
                 hover:text-white hover:bg-surface-100
                 transition-all duration-200

--- a/src/components/ui/NumberStepper.tsx
+++ b/src/components/ui/NumberStepper.tsx
@@ -42,12 +42,12 @@ export function NumberStepper({
 
   const sizeClasses = {
     sm: {
-      button: 'w-8 h-8 text-lg',
+      button: 'w-8 h-8 text-lg min-h-[44px] min-w-[44px]',
       value: 'text-lg min-w-[3rem]',
       container: 'gap-2',
     },
     md: {
-      button: 'w-10 h-10 text-xl',
+      button: 'w-10 h-10 text-xl min-h-[44px] min-w-[44px]',
       value: 'text-xl min-w-[4rem]',
       container: 'gap-3',
     },

--- a/src/components/ui/RadarChart.tsx
+++ b/src/components/ui/RadarChart.tsx
@@ -1,4 +1,14 @@
 import { useMemo } from 'react'
+import {
+  RadarChart as RechartsRadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts'
 
 interface RadarChartProps {
   /** Data for each player - array of { label, values: number[] } */
@@ -31,189 +41,60 @@ export default function RadarChart({
   size = 300,
   showValues = false
 }: RadarChartProps) {
-  const numAxes = data.length
-  const center = size / 2
-  const radius = (size / 2) - 40 // Leave room for labels
-  const levels = 5 // Number of concentric circles
-
-  // Calculate angle for each axis
-  const angleStep = (2 * Math.PI) / numAxes
-  const startAngle = -Math.PI / 2 // Start from top
-
-  // Get max value for normalization
-  const maxValue = useMemo(() => {
-    let max = 0
-    data.forEach(d => {
-      d.values.forEach(v => {
-        if (v > max) max = v
+  // Transform data for recharts format: { label: string, player0: number, player1: number, ... }
+  const chartData = useMemo(() => {
+    return data.map(d => {
+      const entry: Record<string, string | number> = { label: d.label }
+      players.forEach((_, i) => {
+        entry[`player${i}`] = d.values[i] || 0
       })
-    })
-    return max || 1
-  }, [data])
-
-  // Calculate point position on the chart
-  const getPoint = (axisIndex: number, value: number) => {
-    const angle = startAngle + axisIndex * angleStep
-    const normalizedValue = value / maxValue
-    const r = normalizedValue * radius
-    return {
-      x: center + r * Math.cos(angle),
-      y: center + r * Math.sin(angle),
-    }
-  }
-
-  // Generate axis lines and labels
-  const axes = useMemo(() => {
-    return data.map((d, i) => {
-      const angle = startAngle + i * angleStep
-      const endX = center + radius * Math.cos(angle)
-      const endY = center + radius * Math.sin(angle)
-      const labelX = center + (radius + 20) * Math.cos(angle)
-      const labelY = center + (radius + 20) * Math.sin(angle)
-
-      return {
-        line: { x1: center, y1: center, x2: endX, y2: endY },
-        label: { x: labelX, y: labelY, text: d.label },
-      }
-    })
-  }, [data, center, radius, angleStep])
-
-  // Generate concentric level circles
-  const levelCircles = useMemo(() => {
-    return Array.from({ length: levels }, (_, i) => {
-      const r = ((i + 1) / levels) * radius
-      return { r, value: Math.round(((i + 1) / levels) * maxValue) }
-    })
-  }, [levels, radius, maxValue])
-
-  // Generate polygon points for each player
-  const playerPolygons = useMemo(() => {
-    return players.map((player, playerIndex) => {
-      const points = data.map((d, axisIndex) => {
-        const value = d.values[playerIndex] || 0
-        return getPoint(axisIndex, value)
-      })
-
-      const pathData = points
-        .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`)
-        .join(' ') + ' Z'
-
-      return {
-        pathData,
-        points,
-        color: PLAYER_COLORS[playerIndex % PLAYER_COLORS.length],
-        name: player.name,
-      }
+      return entry
     })
   }, [data, players])
 
   return (
-    <div className="flex flex-col items-center gap-4">
-      <svg width={size} height={size} className="overflow-visible">
-        {/* Background circles */}
-        {levelCircles.map((level, i) => (
-          <g key={i}>
-            <circle
-              cx={center}
-              cy={center}
-              r={level.r}
-              fill="none"
-              stroke="rgba(255,255,255,0.1)"
-              strokeWidth="1"
-            />
-            {/* Level value label */}
-            <text
-              x={center + 5}
-              y={center - level.r}
-              fill="rgba(255,255,255,0.3)"
-              fontSize="10"
-              textAnchor="start"
-            >
-              {level.value}
-            </text>
-          </g>
-        ))}
-
-        {/* Axis lines */}
-        {axes.map((axis, i) => (
-          <line
-            key={i}
-            x1={axis.line.x1}
-            y1={axis.line.y1}
-            x2={axis.line.x2}
-            y2={axis.line.y2}
-            stroke="rgba(255,255,255,0.2)"
-            strokeWidth="1"
+    <div className="flex flex-col items-center">
+      <ResponsiveContainer width="100%" height={size}>
+        <RechartsRadarChart data={chartData} cx="50%" cy="50%" outerRadius="70%">
+          <PolarGrid stroke="rgba(255,255,255,0.1)" />
+          <PolarAngleAxis
+            dataKey="label"
+            tick={{ fill: 'rgba(255,255,255,0.8)', fontSize: 11, fontWeight: 500 }}
           />
-        ))}
-
-        {/* Player polygons */}
-        {playerPolygons.map((polygon, i) => (
-          <g key={i}>
-            <path
-              d={polygon.pathData}
-              fill={polygon.color.fill}
-              stroke={polygon.color.stroke}
-              strokeWidth="2"
-            />
-            {/* Data points */}
-            {polygon.points.map((point, j) => (
-              <circle
-                key={j}
-                cx={point.x}
-                cy={point.y}
-                r="4"
-                fill={polygon.color.stroke}
+          <PolarRadiusAxis
+            tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+            axisLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1a1c20',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: '8px',
+              color: '#fff',
+              fontSize: '12px',
+            }}
+          />
+          {players.map((player, i) => {
+            const colors = PLAYER_COLORS[i % PLAYER_COLORS.length]
+            return (
+              <Radar
+                key={player.name}
+                name={player.name}
+                dataKey={`player${i}`}
+                stroke={colors.stroke}
+                fill={colors.fill}
+                strokeWidth={2}
+                dot={showValues ? { r: 4, fill: colors.stroke } : false}
               />
-            ))}
-          </g>
-        ))}
-
-        {/* Axis labels */}
-        {axes.map((axis, i) => (
-          <text
-            key={i}
-            x={axis.label.x}
-            y={axis.label.y}
-            fill="rgba(255,255,255,0.8)"
-            fontSize="11"
-            fontWeight="500"
-            textAnchor="middle"
-            dominantBaseline="middle"
-          >
-            {axis.label.text}
-          </text>
-        ))}
-
-        {/* Value labels if enabled */}
-        {showValues && playerPolygons.map((polygon, playerIdx) => (
-          polygon.points.map((point, axisIdx) => (
-            <text
-              key={`${playerIdx}-${axisIdx}`}
-              x={point.x}
-              y={point.y - 10}
-              fill={polygon.color.stroke}
-              fontSize="9"
-              textAnchor="middle"
-            >
-              {data[axisIdx].values[playerIdx]}
-            </text>
-          ))
-        ))}
-      </svg>
-
-      {/* Legend */}
-      <div className="flex flex-wrap justify-center gap-4">
-        {players.map((player, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <div
-              className="w-3 h-3 rounded-full"
-              style={{ backgroundColor: PLAYER_COLORS[i % PLAYER_COLORS.length].stroke }}
-            />
-            <span className="text-sm text-gray-300">{player.name}</span>
-          </div>
-        ))}
-      </div>
+            )
+          })}
+          <Legend
+            wrapperStyle={{ fontSize: '13px', color: '#d1d5db' }}
+            iconType="circle"
+            iconSize={10}
+          />
+        </RechartsRadarChart>
+      </ResponsiveContainer>
     </div>
   )
 }

--- a/src/pages/Contracts.tsx
+++ b/src/pages/Contracts.tsx
@@ -8,6 +8,7 @@ import { getTeamLogo } from '../utils/teamLogos'
 import { POSITION_COLORS } from '../components/ui/PositionBadge'
 import { PlayerStatsModal, type PlayerInfo, type PlayerStats } from '../components/PlayerStatsModal'
 import { getPlayerPhotoUrl } from '../utils/player-images'
+import haptic from '../utils/haptics'
 
 interface ContractsProps {
   leagueId: string
@@ -462,6 +463,7 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
     }))
     const result = await contractApi.saveDrafts(leagueId, renewals, newContracts, Array.from(localReleases), exitDecisionsArray)
     if (result.success) {
+      haptic.save()
       setSuccess('Bozze salvate! Puoi tornare a modificarle in qualsiasi momento.')
       await loadContracts() // Ricarica per aggiornare i draft
     } else {
@@ -508,6 +510,7 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
     // Invia al backend
     const result = await contractApi.consolidateAll(leagueId, renewals, newContracts)
     if (result.success) {
+      haptic.success()
       setSuccess(result.message || 'Contratti consolidati!')
       setIsConsolidated(true)
       const data = result.data as { consolidatedAt?: string }
@@ -1144,15 +1147,15 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                           <button
                             onClick={() => updatePendingEdit(pending.rosterId, 'newSalary', String(Math.max(pending.minSalary, currentSalary - 1)))}
                             disabled={!inContrattiPhase || isConsolidated || currentSalary <= pending.minSalary}
-                            className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
+                            className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
                           >−</button>
-                          <div className="flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">
+                          <div className="flex-1 px-2 py-2 min-h-[44px] flex items-center justify-center bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">
                             {currentSalary}M
                           </div>
                           <button
                             onClick={() => updatePendingEdit(pending.rosterId, 'newSalary', String(currentSalary + 1))}
                             disabled={!inContrattiPhase || isConsolidated}
-                            className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
+                            className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
                           >+</button>
                         </div>
                       </div>
@@ -1162,15 +1165,15 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                           <button
                             onClick={() => updatePendingEdit(pending.rosterId, 'newDuration', String(Math.max(1, currentDuration - 1)))}
                             disabled={!inContrattiPhase || isConsolidated || currentDuration <= 1}
-                            className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
+                            className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
                           >−</button>
-                          <div className={`flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-center font-medium ${getDurationColor(currentDuration)}`}>
+                          <div className={`flex-1 px-2 py-2 min-h-[44px] flex items-center justify-center bg-surface-300 border-y border-primary-500/30 text-center font-medium ${getDurationColor(currentDuration)}`}>
                             {currentDuration}s
                           </div>
                           <button
                             onClick={() => updatePendingEdit(pending.rosterId, 'newDuration', String(Math.min(4, currentDuration + 1)))}
                             disabled={!inContrattiPhase || isConsolidated || currentDuration >= 4}
-                            className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
+                            className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
                           >+</button>
                         </div>
                       </div>
@@ -1609,15 +1612,15 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                             <button
                               onClick={() => updateLocalEdit(contract.id, 'newSalary', String(Math.max(minSalaryAllowed, newSalary - 1)))}
                               disabled={!canDecreaseSalary}
-                              className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
+                              className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
                               title={!canDecreaseSalary ? (contract.canSpalmare ? 'Ingaggio minimo raggiunto' : 'Riduci prima la durata per diminuire l\'ingaggio') : undefined}
                             >−</button>
-                            <div className="flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">
+                            <div className="flex-1 px-2 py-2 min-h-[44px] flex items-center justify-center bg-surface-300 border-y border-primary-500/30 text-white text-center font-medium">
                               {newSalary}M
                             </div>
                             <button
                               onClick={() => updateLocalEdit(contract.id, 'newSalary', String(newSalary + 1))}
-                              className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold"
+                              className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold"
                             >+</button>
                           </div>
                         </div>
@@ -1627,16 +1630,16 @@ export function Contracts({ leagueId, onNavigate }: ContractsProps) {
                             <button
                               onClick={() => updateLocalEdit(contract.id, 'newDuration', String(newDuration - 1))}
                               disabled={!canDecreaseDuration}
-                              className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
+                              className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-l text-white font-bold disabled:opacity-30"
                               title={!canDecreaseDuration && contract.canSpalmare ? 'Aumenta l\'ingaggio per ridurre la durata' : undefined}
                             >−</button>
-                            <div className={`flex-1 px-2 py-2 bg-surface-300 border-y border-primary-500/30 text-center font-medium ${getDurationColor(newDuration)}`}>
+                            <div className={`flex-1 px-2 py-2 min-h-[44px] flex items-center justify-center bg-surface-300 border-y border-primary-500/30 text-center font-medium ${getDurationColor(newDuration)}`}>
                               {newDuration}s
                             </div>
                             <button
                               onClick={() => updateLocalEdit(contract.id, 'newDuration', String(newDuration + 1))}
                               disabled={newDuration >= 4 || !canIncreaseDuration}
-                              className="px-3 py-2 bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
+                              className="px-3 py-2 min-h-[44px] min-w-[44px] bg-surface-300 border border-primary-500/30 rounded-r text-white font-bold disabled:opacity-30"
                               title={!canIncreaseDuration ? 'Aumenta prima l\'ingaggio per estendere la durata' : undefined}
                             >+</button>
                           </div>

--- a/src/pages/ManagerDashboard.tsx
+++ b/src/pages/ManagerDashboard.tsx
@@ -412,31 +412,55 @@ export function ManagerDashboard({ leagueId, onNavigate }: ManagerDashboardProps
                     {(roster[pos]?.length ?? 0) === 0 ? (
                       <p className="p-4 text-gray-400 text-sm text-center">Nessun giocatore</p>
                     ) : (
-                      <table className="w-full">
-                        <thead className="bg-gray-50">
+                      <>
+                      {/* Mobile: card list */}
+                      <div className="md:hidden divide-y divide-surface-50/20">
+                        {(roster[pos] ?? []).map(entry => (
+                          <div key={entry.id} className="px-4 py-3 flex items-center justify-between">
+                            <div className="min-w-0 flex-1">
+                              <p className="font-medium text-white truncate">{entry.player.name}</p>
+                              <p className="text-xs text-gray-500">{entry.player.team}</p>
+                            </div>
+                            <div className="flex gap-4 text-sm flex-shrink-0">
+                              <div className="text-right">
+                                <div className="text-[10px] text-gray-500">Costo</div>
+                                <div className="font-mono text-white">{entry.acquisitionPrice}</div>
+                              </div>
+                              <div className="text-right">
+                                <div className="text-[10px] text-gray-500">Quot.</div>
+                                <div className="font-mono text-gray-400">{entry.player.quotation}</div>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      {/* Desktop: table */}
+                      <table className="w-full hidden md:table">
+                        <thead className="bg-surface-300">
                           <tr>
-                            <th className="px-4 py-2 text-left text-xs text-gray-500">Giocatore</th>
-                            <th className="px-4 py-2 text-right text-xs text-gray-500">Costo</th>
-                            <th className="px-4 py-2 text-right text-xs text-gray-500">Quot.</th>
+                            <th className="px-4 py-2 text-left text-xs text-gray-400">Giocatore</th>
+                            <th className="px-4 py-2 text-right text-xs text-gray-400">Costo</th>
+                            <th className="px-4 py-2 text-right text-xs text-gray-400">Quot.</th>
                           </tr>
                         </thead>
-                        <tbody className="divide-y">
+                        <tbody className="divide-y divide-surface-50/20">
                           {(roster[pos] ?? []).map(entry => (
-                            <tr key={entry.id} className="hover:bg-gray-50">
+                            <tr key={entry.id} className="hover:bg-surface-300/30">
                               <td className="px-4 py-3">
-                                <p className="font-medium">{entry.player.name}</p>
+                                <p className="font-medium text-white">{entry.player.name}</p>
                                 <p className="text-xs text-gray-500">{entry.player.team}</p>
                               </td>
-                              <td className="px-4 py-3 text-right font-mono">
+                              <td className="px-4 py-3 text-right font-mono text-white">
                                 {entry.acquisitionPrice}
                               </td>
-                              <td className="px-4 py-3 text-right font-mono text-gray-500">
+                              <td className="px-4 py-3 text-right font-mono text-gray-400">
                                 {entry.player.quotation}
                               </td>
                             </tr>
                           ))}
                         </tbody>
                       </table>
+                      </>
                     )}
                   </CardContent>
                 </Card>
@@ -452,22 +476,53 @@ export function ManagerDashboard({ leagueId, onNavigate }: ManagerDashboardProps
               <CardTitle>Tutti i Contratti</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
-              <table className="w-full">
-                <thead className="bg-gray-50">
+              {/* Mobile: contract cards */}
+              <div className="md:hidden divide-y divide-surface-50/20">
+                {allPlayers.map(entry => {
+                  const posConfig = POSITION_CONFIG[entry.player.position as keyof typeof POSITION_CONFIG]
+                  const statusBadge = !entry.contract
+                    ? <span className="px-2 py-0.5 bg-danger-500/20 text-danger-400 rounded text-xs">Da impostare</span>
+                    : entry.contract.duration === 0
+                      ? <span className="px-2 py-0.5 bg-danger-500/20 text-danger-400 rounded text-xs">Scaduto</span>
+                      : entry.contract.duration === 1
+                        ? <span className="px-2 py-0.5 bg-warning-500/20 text-warning-400 rounded text-xs">In scadenza</span>
+                        : <span className="px-2 py-0.5 bg-secondary-500/20 text-secondary-400 rounded text-xs">Attivo</span>
+                  return (
+                    <div key={entry.id} className="px-4 py-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className={`px-1.5 py-0.5 rounded text-xs font-bold ${posConfig.bgClass} ${posConfig.textClass}`}>{entry.player.position}</span>
+                        <span className="font-medium text-white flex-1 truncate">{entry.player.name}</span>
+                        {statusBadge}
+                      </div>
+                      <div className="flex justify-between text-xs text-gray-400">
+                        <span>{entry.player.team}</span>
+                        <div className="flex gap-3">
+                          <span>Ing. <span className="text-white font-medium">{entry.contract?.salary || '-'}</span></span>
+                          <span>Dur. <span className={`font-medium ${entry.contract && entry.contract.duration <= 1 ? 'text-warning-400' : 'text-white'}`}>{entry.contract ? `${entry.contract.duration}s` : '-'}</span></span>
+                          <span>Cl. <span className="text-accent-400 font-medium">{entry.contract?.rescissionClause || '-'}</span></span>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              {/* Desktop: table */}
+              <table className="w-full hidden md:table">
+                <thead className="bg-surface-300">
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs text-gray-500">Giocatore</th>
-                    <th className="px-4 py-3 text-center text-xs text-gray-500">Ruolo</th>
-                    <th className="px-4 py-3 text-right text-xs text-gray-500">Ingaggio</th>
-                    <th className="px-4 py-3 text-right text-xs text-gray-500">Durata</th>
-                    <th className="px-4 py-3 text-right text-xs text-gray-500">Clausola</th>
-                    <th className="px-4 py-3 text-right text-xs text-gray-500">Stato</th>
+                    <th className="px-4 py-3 text-left text-xs text-gray-400">Giocatore</th>
+                    <th className="px-4 py-3 text-center text-xs text-gray-400">Ruolo</th>
+                    <th className="px-4 py-3 text-right text-xs text-gray-400">Ingaggio</th>
+                    <th className="px-4 py-3 text-right text-xs text-gray-400">Durata</th>
+                    <th className="px-4 py-3 text-right text-xs text-gray-400">Clausola</th>
+                    <th className="px-4 py-3 text-right text-xs text-gray-400">Stato</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y">
+                <tbody className="divide-y divide-surface-50/20">
                   {allPlayers.map(entry => (
-                    <tr key={entry.id} className="hover:bg-gray-50">
+                    <tr key={entry.id} className="hover:bg-surface-300/30">
                       <td className="px-4 py-3">
-                        <p className="font-medium">{entry.player.name}</p>
+                        <p className="font-medium text-white">{entry.player.name}</p>
                         <p className="text-xs text-gray-500">{entry.player.team}</p>
                       </td>
                       <td className="px-4 py-3 text-center">
@@ -475,30 +530,30 @@ export function ManagerDashboard({ leagueId, onNavigate }: ManagerDashboardProps
                           {entry.player.position}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-right font-mono">
+                      <td className="px-4 py-3 text-right font-mono text-white">
                         {entry.contract?.salary || '-'}
                       </td>
                       <td className="px-4 py-3 text-right">
                         {entry.contract ? (
-                          <span className={entry.contract.duration <= 1 ? 'text-warning-600 font-medium' : ''}>
+                          <span className={entry.contract.duration <= 1 ? 'text-warning-400 font-medium' : 'text-white'}>
                             {entry.contract.duration} sem.
                           </span>
                         ) : (
-                          <span className="text-danger-500">No contratto</span>
+                          <span className="text-danger-400">No contratto</span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-right font-mono">
+                      <td className="px-4 py-3 text-right font-mono text-white">
                         {entry.contract?.rescissionClause || '-'}
                       </td>
                       <td className="px-4 py-3 text-right">
                         {!entry.contract ? (
-                          <span className="px-2 py-1 bg-danger-100 text-danger-700 rounded text-xs">Da impostare</span>
+                          <span className="px-2 py-1 bg-danger-500/20 text-danger-400 rounded text-xs">Da impostare</span>
                         ) : entry.contract.duration === 0 ? (
-                          <span className="px-2 py-1 bg-danger-100 text-danger-700 rounded text-xs">Scaduto</span>
+                          <span className="px-2 py-1 bg-danger-500/20 text-danger-400 rounded text-xs">Scaduto</span>
                         ) : entry.contract.duration === 1 ? (
-                          <span className="px-2 py-1 bg-warning-100 text-warning-700 rounded text-xs">In scadenza</span>
+                          <span className="px-2 py-1 bg-warning-500/20 text-warning-400 rounded text-xs">In scadenza</span>
                         ) : (
-                          <span className="px-2 py-1 bg-success-100 text-success-700 rounded text-xs">Attivo</span>
+                          <span className="px-2 py-1 bg-secondary-500/20 text-secondary-400 rounded text-xs">Attivo</span>
                         )}
                       </td>
                     </tr>

--- a/src/pages/Rubata.tsx
+++ b/src/pages/Rubata.tsx
@@ -7,6 +7,8 @@ import { getPlayerPhotoUrl } from '../utils/player-images'
 import { usePusherAuction } from '../services/pusher.client'
 import { ContractModifierModal } from '../components/ContractModifier'
 import { PlayerStatsModal, type PlayerInfo, type ComputedSeasonStats } from '../components/PlayerStatsModal'
+import { RubataStepper } from '../components/rubata/RubataStepper'
+import { PreferenceModal } from '../components/rubata/PreferenceModal'
 
 // Componente logo squadra
 function TeamLogo({ team }: { team: string }) {
@@ -182,169 +184,7 @@ const POSITION_COLORS: Record<string, string> = {
   A: 'bg-red-500/20 text-red-400 border-red-500/30',
 }
 
-// Componente modale preferenze separato per evitare re-render del componente principale
-interface PreferenceModalProps {
-  player: BoardPlayerWithPreference
-  onClose: () => void
-  onSave: (data: { maxBid: number | null; priority: number | null; notes: string | null }) => Promise<void>
-  onDelete: () => Promise<void>
-  isSubmitting: boolean
-}
-
-function PreferenceModal({ player, onClose, onSave, onDelete, isSubmitting }: PreferenceModalProps) {
-  const [formData, setFormData] = useState({
-    maxBid: player.preference?.maxBid?.toString() || '',
-    priority: player.preference?.priority?.toString() || '',
-    notes: player.preference?.notes || '',
-  })
-
-  const handleSave = async () => {
-    await onSave({
-      maxBid: formData.maxBid ? parseInt(formData.maxBid) : null,
-      priority: formData.priority ? parseInt(formData.priority) : null,
-      notes: formData.notes || null,
-    })
-  }
-
-  // Controlla se c'è almeno una strategia impostata
-  const hasStrategy = formData.maxBid || formData.priority || formData.notes
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-fadeIn">
-      <div className="bg-surface-200 rounded-2xl p-6 max-w-md w-full shadow-2xl border border-indigo-500/50">
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 bg-white rounded p-1">
-            <TeamLogo team={player.playerTeam} />
-          </div>
-          <div>
-            <h3 className="font-bold text-white">{player.playerName}</h3>
-            <p className="text-sm text-gray-400">{player.playerTeam} • {player.rubataPrice}M</p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="ml-auto w-8 h-8 rounded-full bg-surface-300 text-gray-400 hover:bg-surface-50/20 flex items-center justify-center"
-          >
-            ✕
-          </button>
-        </div>
-
-        {/* Form */}
-        <div className="space-y-4">
-          {/* Max bid with +/- buttons */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">Budget massimo</label>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => setFormData(p => ({
-                  ...p,
-                  maxBid: String(Math.max(0, (parseInt(p.maxBid) || 0) - 5))
-                }))}
-                disabled={!formData.maxBid || parseInt(formData.maxBid) <= 0}
-                className="w-10 h-10 rounded-lg bg-surface-300 border border-surface-50/30 text-white text-xl font-bold hover:bg-surface-50/20 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
-              >
-                −
-              </button>
-              <div className="flex-1 text-center">
-                <input
-                  type="number"
-                  value={formData.maxBid}
-                  onChange={e => setFormData(p => ({ ...p, maxBid: e.target.value }))}
-                  placeholder="—"
-                  className="w-full text-center text-2xl font-bold bg-transparent text-white focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
-                <p className="text-xs text-gray-500">milioni</p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setFormData(p => ({
-                  ...p,
-                  maxBid: String((parseInt(p.maxBid) || 0) + 5)
-                }))}
-                className="w-10 h-10 rounded-lg bg-surface-300 border border-surface-50/30 text-white text-xl font-bold hover:bg-surface-50/20 transition-all"
-              >
-                +
-              </button>
-            </div>
-            {formData.maxBid && (
-              <button
-                type="button"
-                onClick={() => setFormData(p => ({ ...p, maxBid: '' }))}
-                className="mt-1 text-xs text-gray-500 hover:text-gray-400"
-              >
-                Rimuovi limite
-              </button>
-            )}
-          </div>
-
-          {/* Priority with star rating */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">Priorità</label>
-            <div className="flex items-center justify-center gap-1">
-              {[1, 2, 3, 4, 5].map(star => {
-                const currentPriority = parseInt(formData.priority) || 0
-                const isActive = star <= currentPriority
-                return (
-                  <button
-                    type="button"
-                    key={star}
-                    onClick={() => setFormData(p => ({
-                      ...p,
-                      priority: p.priority === String(star) ? '' : String(star)
-                    }))}
-                    className={`w-10 h-10 text-2xl transition-all transform hover:scale-110 ${
-                      isActive ? 'text-purple-400' : 'text-gray-600 hover:text-purple-400/50'
-                    }`}
-                    title={`Priorità ${star}`}
-                  >
-                    {isActive ? '★' : '☆'}
-                  </button>
-                )
-              })}
-            </div>
-            <p className="text-center text-xs text-gray-500 mt-1">
-              {formData.priority ? `Priorità ${formData.priority} (clicca per rimuovere)` : 'Clicca per impostare'}
-            </p>
-          </div>
-
-          {/* Notes */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Note private</label>
-            <textarea
-              value={formData.notes}
-              onChange={e => setFormData(p => ({ ...p, notes: e.target.value }))}
-              placeholder="Appunti personali..."
-              rows={3}
-              className="w-full px-3 py-2 bg-surface-300 border border-surface-50/20 rounded-lg text-white placeholder-gray-500 focus:border-indigo-500/50 focus:outline-none resize-none"
-            />
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex gap-2 mt-6">
-          {player.preference && (
-            <Button
-              onClick={onDelete}
-              disabled={isSubmitting}
-              variant="outline"
-              className="border-danger-500/50 text-danger-400 hover:bg-danger-500/10"
-            >
-              Rimuovi
-            </Button>
-          )}
-          <Button onClick={onClose} variant="outline" className="flex-1">
-            Annulla
-          </Button>
-          <Button onClick={handleSave} disabled={isSubmitting} className="flex-1">
-            Salva
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
+// PreferenceModal è ora estratto in ../components/rubata/PreferenceModal.tsx
 
 export function Rubata({ leagueId, onNavigate }: RubataProps) {
   const [isLoading, setIsLoading] = useState(true)
@@ -2387,6 +2227,9 @@ export function Rubata({ leagueId, onNavigate }: RubataProps) {
 
             {/* Main Content */}
             <div className="lg:col-span-4">
+            {/* Stepper visivo flusso rubata */}
+            <RubataStepper currentState={rubataState} className="mb-4" />
+
             {/* Timer e stato corrente - sticky on mobile for visibility */}
             <div className="mb-6 bg-surface-200 rounded-2xl border-2 border-primary-500/50 overflow-hidden sticky top-16 z-20 lg:relative lg:top-0">
               <div className="p-5 bg-primary-500/10">

--- a/src/pages/StrategieRubata.tsx
+++ b/src/pages/StrategieRubata.tsx
@@ -1082,14 +1082,14 @@ export function StrategieRubata({ onNavigate }: { onNavigate: (page: string) => 
                           {/* Max Bid */}
                           <div className="flex items-center gap-1">
                             <span className="text-[10px] text-gray-500 uppercase">Max:</span>
-                            <button onClick={() => updateLocalStrategy(player.playerId, 'maxBid', Math.max(0, (parseInt(local.maxBid) || 0) - 1).toString())} className="w-6 h-6 rounded bg-surface-300/70 text-gray-400 text-sm font-bold">−</button>
-                            <input type="number" value={local.maxBid} onChange={(e) => updateLocalStrategy(player.playerId, 'maxBid', e.target.value)} placeholder="-" className="w-12 px-1 py-1 bg-surface-300/50 border border-surface-50/30 rounded text-white text-center text-sm" />
-                            <button onClick={() => updateLocalStrategy(player.playerId, 'maxBid', ((parseInt(local.maxBid) || 0) + 1).toString())} className="w-6 h-6 rounded bg-surface-300/70 text-gray-400 text-sm font-bold">+</button>
+                            <button onClick={() => updateLocalStrategy(player.playerId, 'maxBid', Math.max(0, (parseInt(local.maxBid) || 0) - 1).toString())} className="w-6 h-6 min-h-[44px] min-w-[44px] rounded bg-surface-300/70 text-gray-400 text-sm font-bold flex items-center justify-center">−</button>
+                            <input type="number" value={local.maxBid} onChange={(e) => updateLocalStrategy(player.playerId, 'maxBid', e.target.value)} placeholder="-" className="w-12 px-1 py-1 min-h-[44px] bg-surface-300/50 border border-surface-50/30 rounded text-white text-center text-sm" />
+                            <button onClick={() => updateLocalStrategy(player.playerId, 'maxBid', ((parseInt(local.maxBid) || 0) + 1).toString())} className="w-6 h-6 min-h-[44px] min-w-[44px] rounded bg-surface-300/70 text-gray-400 text-sm font-bold flex items-center justify-center">+</button>
                           </div>
                           {/* Priority - increased size #186 */}
                           <div className="flex items-center gap-0.5 ml-auto">
                             {[1, 2, 3, 4, 5].map(star => (
-                              <button key={star} onClick={() => updateLocalStrategy(player.playerId, 'priority', local.priority === star ? 0 : star)} className={`w-8 h-8 text-xl ${local.priority >= star ? 'text-purple-400' : 'text-gray-600'}`}>★</button>
+                              <button key={star} onClick={() => updateLocalStrategy(player.playerId, 'priority', local.priority === star ? 0 : star)} className={`w-8 h-8 min-h-[44px] min-w-[44px] text-xl flex items-center justify-center ${local.priority >= star ? 'text-purple-400' : 'text-gray-600'}`}>★</button>
                             ))}
                           </div>
                         </div>

--- a/src/pages/Trades.tsx
+++ b/src/pages/Trades.tsx
@@ -8,6 +8,7 @@ import { getPlayerPhotoUrl } from '../utils/player-images'
 import { POSITION_GRADIENTS } from '../components/ui/PositionBadge'
 import { ContractModifierModal, type PlayerInfo, type ContractData } from '../components/ContractModifier'
 import { EmptyState } from '../components/ui/EmptyState'
+import haptic from '../utils/haptics'
 
 interface TradesProps {
   leagueId: string
@@ -751,6 +752,7 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
     })
 
     if (res.success) {
+      haptic.send()
       setSuccess('Offerta inviata!')
       // Reset form
       setSelectedMemberId('')
@@ -866,55 +868,50 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
     <div className="min-h-screen bg-dark-300">
       <Navigation currentPage="trades" leagueId={leagueId} isLeagueAdmin={isLeagueAdmin} onNavigate={onNavigate} />
 
-      <main className="max-w-[1600px] mx-auto px-4 py-8">
+      <main className="max-w-[1600px] mx-auto px-4 py-4 md:py-8">
         {/* Phase Status */}
-        <Card className="mb-6">
-          <CardContent className="py-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-white">Fase corrente</p>
-                <p className={`text-sm ${isInTradePhase ? 'text-secondary-400' : 'text-gray-400'}`}>
+        <Card className="mb-4 md:mb-6">
+          <CardContent className="py-3 md:py-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <p className="font-medium text-white text-sm md:text-base">Fase corrente</p>
+                <p className={`text-xs md:text-sm ${isInTradePhase ? 'text-secondary-400' : 'text-gray-400'} truncate`}>
                   {currentSession ? currentSession.currentPhase : 'Nessuna sessione attiva'}
                 </p>
               </div>
-              <div className={`px-3 py-1 rounded-full text-sm font-medium ${
+              <div className={`px-2.5 md:px-3 py-1 rounded-full text-xs md:text-sm font-medium flex-shrink-0 ${
                 isInTradePhase
                   ? 'bg-secondary-500/20 text-secondary-400 border border-secondary-500/40'
                   : 'bg-surface-300 text-gray-400'
               }`}>
-                {isInTradePhase ? 'Scambi Attivi' : 'Scambi Non Disponibili'}
+                {isInTradePhase ? 'Scambi Attivi' : 'Non Disponibili'}
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Tabs */}
-        <div className="flex gap-2 mb-6 flex-wrap">
-          <Button
-            variant={activeTab === 'create' ? 'primary' : 'outline'}
-            onClick={() => setActiveTab('create')}
-            disabled={!isInTradePhase}
-          >
-            + Nuova Offerta
-          </Button>
-          <Button
-            variant={activeTab === 'received' ? 'primary' : 'outline'}
-            onClick={() => setActiveTab('received')}
-          >
-            Ricevute ({receivedOffers.length})
-          </Button>
-          <Button
-            variant={activeTab === 'sent' ? 'primary' : 'outline'}
-            onClick={() => setActiveTab('sent')}
-          >
-            Inviate ({sentOffers.length})
-          </Button>
-          <Button
-            variant={activeTab === 'history' ? 'primary' : 'outline'}
-            onClick={() => setActiveTab('history')}
-          >
-            Storico
-          </Button>
+        {/* Tabs - compact scrollable on mobile, flex-wrap on desktop */}
+        <div className="flex gap-2 mb-6 overflow-x-auto md:overflow-x-visible md:flex-wrap scrollbar-hide -mx-4 px-4 md:mx-0 md:px-0">
+          {([
+            { key: 'create' as const, label: '+ Nuova', labelDesktop: '+ Nuova Offerta', disabled: !isInTradePhase },
+            { key: 'received' as const, label: `Ricevute (${receivedOffers.length})`, disabled: false },
+            { key: 'sent' as const, label: `Inviate (${sentOffers.length})`, disabled: false },
+            { key: 'history' as const, label: 'Storico', disabled: false },
+          ]).map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              disabled={tab.disabled}
+              className={`whitespace-nowrap flex-shrink-0 px-4 py-2.5 rounded-lg text-sm font-semibold transition-all min-h-[44px] ${
+                activeTab === tab.key
+                  ? 'bg-primary-500 text-white shadow-lg shadow-primary-500/25'
+                  : 'bg-surface-200 text-gray-400 border border-surface-50/30 hover:text-white hover:border-primary-500/50'
+              } ${tab.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            >
+              <span className="md:hidden">{tab.label}</span>
+              <span className="hidden md:inline">{tab.labelDesktop || tab.label}</span>
+            </button>
+          ))}
         </div>
 
         {/* Received Offers */}
@@ -1795,7 +1792,7 @@ export function Trades({ leagueId, onNavigate, highlightOfferId }: TradesProps) 
                   <button
                     key={key}
                     onClick={() => setHistoryFilter(key)}
-                    className={`px-4 py-1.5 text-xs font-semibold rounded-full border transition-colors ${
+                    className={`px-4 py-1.5 min-h-[44px] text-xs font-semibold rounded-full border transition-colors ${
                       historyFilter === key
                         ? 'bg-accent-500/20 text-accent-400 border-accent-500/40'
                         : 'bg-surface-200 text-gray-400 border-surface-50/20 hover:border-surface-50/40'

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -3,7 +3,7 @@
  * Uses the Vibration API where available
  */
 
-export type HapticPattern = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'bid' | 'outbid' | 'win'
+export type HapticPattern = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'bid' | 'outbid' | 'win' | 'save' | 'send' | 'approve' | 'reject'
 
 // Vibration patterns in milliseconds
 const PATTERNS: Record<HapticPattern, number | number[]> = {
@@ -20,7 +20,13 @@ const PATTERNS: Record<HapticPattern, number | number[]> = {
   // Auction-specific patterns
   bid: 50,                     // Bid sent
   outbid: [50, 30, 50],        // Someone outbid you
-  win: [100, 50, 100, 50, 200] // You won the auction!
+  win: [100, 50, 100, 50, 200], // You won the auction!
+
+  // Action patterns
+  save: [30, 30, 60],           // Save confirmation
+  send: [40, 40, 80],           // Send offer/message
+  approve: [50, 50, 100],       // Approve action
+  reject: [60, 30, 60, 30, 60]  // Reject action (staccato)
 }
 
 /**
@@ -75,6 +81,10 @@ export const haptic = {
   bid: () => vibrate('bid'),
   outbid: () => vibrate('outbid'),
   win: () => vibrate('win'),
+  save: () => vibrate('save'),
+  send: () => vibrate('send'),
+  approve: () => vibrate('approve'),
+  reject: () => vibrate('reject'),
 }
 
 export default haptic


### PR DESCRIPTION
## Summary
- **MOB-022**: Haptic feedback su Trades (send) e AdminPanel (approve/reject)
- **MOB-007**: Touch targets 44x44px su NumberStepper, Modal, DurationSlider, BottomSheet, StrategieRubata
- **MOB-006**: Layout Trades mobile con tab scrollabili e card compatte
- **MOB-015**: Editing contratti touch-friendly con stepper 44px
- **TASK-014**: RubataStepper visuale per flusso rubata (desktop pills + mobile dots)
- **MOB-005**: Card view mobile per roster e contratti in ManagerDashboard
- **TASK-009**: Migrazione RadarChart da SVG custom a recharts
- **TASK-002**: AdminPanel tab scrollabili mobile + card view membri
- **TASK-006**: Estrazione PreferenceModal e RubataStepper in src/components/rubata/

## Dettaglio modifiche
- 15 file modificati, +578 / -441 righe
- 3 nuovi componenti in `src/components/rubata/` (RubataStepper, PreferenceModal, index barrel)
- Pattern mobile consistente: tab scrollabili + card view + touch targets 44px
- RadarChart migrato a recharts mantenendo stessa interfaccia props

## Test plan
- [ ] Verificare touch targets 44x44px su mobile (NumberStepper, Modal, DurationSlider, BottomSheet)
- [ ] Verificare tab scrollabili su Trades e AdminPanel in mobile
- [ ] Verificare card view roster e contratti su ManagerDashboard mobile
- [ ] Verificare RubataStepper in tutte le fasi rubata (desktop + mobile)
- [ ] Verificare haptic feedback su invio trade e azioni admin
- [ ] Verificare RadarChart con recharts nei confronti giocatori
- [ ] Verificare PreferenceModal estratto funziona correttamente in Rubata

🤖 Generated with [Claude Code](https://claude.com/claude-code)